### PR TITLE
fix: add missing IAM permissions for Deploy CI (#16 follow-up)

### DIFF
--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -211,7 +211,7 @@ resource "aws_iam_role_policy" "github_actions" {
       },
       {
         Effect   = "Allow"
-        Action   = ["apigateway:GET"]
+        Action   = ["apigateway:GET", "apigateway:POST", "apigateway:PUT", "apigateway:PATCH", "apigateway:DELETE"]
         Resource = ["*"]
       },
       {
@@ -241,7 +241,7 @@ resource "aws_iam_role_policy" "github_actions" {
       },
       {
         Effect   = "Allow"
-        Action   = ["dynamodb:DescribeTable", "dynamodb:DescribeTimeToLive", "dynamodb:ListTagsOfResource"]
+        Action   = ["dynamodb:DescribeTable", "dynamodb:DescribeTimeToLive", "dynamodb:ListTagsOfResource", "dynamodb:CreateTable", "dynamodb:DeleteTable", "dynamodb:UpdateTable", "dynamodb:TagResource", "dynamodb:UntagResource"]
         Resource = ["*"]
       },
     ]


### PR DESCRIPTION
## 関連イシュー
PR #16 マージ後の Deploy CI 失敗を修正。

## 変更内容
`github_actions` IAM ロールに不足していた権限を追加:

- `apigateway:POST/PUT/PATCH/DELETE` — API Gateway CORS/route 更新に必要
- `dynamodb:CreateTable/DeleteTable/UpdateTable/TagResource/UntagResource` — DynamoDB テーブル（item-configs, push-subscriptions）作成に必要

## 原因
PR #16 で追加した以下のリソースが、GitHub Actions ロールの権限不足で作成できなかった:
- `health-logger-prod-item-configs` DynamoDB テーブル
- `health-logger-prod-push-subscriptions` DynamoDB テーブル
- API Gateway CORS 更新（DELETE メソッド追加）

## テスト確認
- [x] `terraform fmt -check -recursive` → エラーなし
- [ ] Deploy CI が通ることを確認（PR マージ後）

## 注意
このPRをマージする前に、ローカルで `terraform apply -target=aws_iam_role_policy.github_actions` を実行してIAMポリシーを先に適用する必要があります。