### PR TITLE
fix: remove dt column from get_latest (COLUMN_NOT_FOUND fix)

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -47,5 +47,4 @@ export interface LatestRecord {
   app_version:      string
   custom_fields:    string
   written_at:       string
-  dt:               string
 }

--- a/lambda/get_latest/handler.py
+++ b/lambda/get_latest/handler.py
@@ -39,7 +39,7 @@ def lambda_handler(event, context):
 
     query = f"""
         SELECT id, record_type, fatigue_score, mood_score, motivation_score, flags, note,
-               recorded_at, timezone, device_id, app_version, custom_fields, written_at, dt
+               recorded_at, timezone, device_id, app_version, custom_fields, written_at
         FROM health_records
         WHERE user_id = '{user_id}'
         ORDER BY recorded_at DESC


### PR DESCRIPTION
## 変更内容
`get_latest` クエリから `dt` カラムを削除。`LatestRecord` 型定義からも削除。

## 原因
`dt` は Glue/Iceberg テーブルスキーマに存在しないカラムだが、元のクエリに含まれていた。
`getLatest()` を実際に呼び出す UI（RecordHistory）が今回のPR #21 で初めて追加されたため発覚。

## テスト確認
- [x] `pytest lambda/get_latest/ -v` → 6件 PASSED
- [x] `npx tsc --noEmit` → エラーなし