### PR TITLE
fix: correct timezone display for recorded_at

### DIFF
--- a/frontend/src/components/RecordHistory.tsx
+++ b/frontend/src/components/RecordHistory.tsx
@@ -10,7 +10,9 @@ interface Props {
 
 function formatTime(isoStr: string): string {
   try {
-    return new Date(isoStr).toLocaleString('ja-JP', {
+    // Athena returns timestamps without timezone (UTC); append 'Z' to parse as UTC
+    const utcStr = isoStr.includes('T') ? isoStr : isoStr.replace(' ', 'T') + 'Z'
+    return new Date(utcStr).toLocaleString('ja-JP', {
       month: 'numeric', day: 'numeric',
       hour: '2-digit', minute: '2-digit',
     })


### PR DESCRIPTION
## 変更内容
Athena が返す `recorded_at` タイムスタンプ（例: `2026-03-08 11:34:xx`）はタイムゾーン表記なしの UTC。
`new Date()` がローカル時間として解釈するため、JST ユーザーには 9 時間ずれた時刻が表示されていた。
文字列末尾に `Z` を付与して UTC として正しく解釈させる。

## テスト確認
- [x] `npx tsc --noEmit` → エラーなし