### PR TITLE
docs: update infrastructure diagram to current serverless architecture

### DIFF
--- a/docs/infrastructure.drawio
+++ b/docs/infrastructure.drawio
@@ -1,331 +1,236 @@
-<mxfile host="app.diagrams.net" modified="2026-02-28T00:00:00.000Z" agent="Claude Code" version="21.0.0" type="device">
-  <diagram id="health-logger-infra" name="Health Logger Infrastructure">
+<?xml version="1.0" encoding="UTF-8"?>
+<mxfile host="app.diagrams.net" modified="2026-03-08T00:00:00.000Z" agent="Claude Code" version="24.0.0" type="device">
+  <diagram id="health-logger-infra-serverless" name="Health Logger Infrastructure">
     <mxGraphModel dx="1422" dy="762" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1654" pageHeight="1169" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
 
         <!-- ===== TITLE ===== -->
-        <mxCell id="title" value="Health Logger — AWS インフラ構成図" style="text;html=1;fontSize=20;fontStyle=1;align=center;verticalAlign=middle;" vertex="1" parent="1">
-          <mxGeometry x="477" y="20" width="700" height="40" as="geometry" />
+        <mxCell id="title" value="Health Logger — サーバーレス AWS インフラ構成図" style="text;html=1;fontSize=20;fontStyle=1;align=center;verticalAlign=middle;" vertex="1" parent="1">
+          <mxGeometry x="400" y="20" width="750" height="40" as="geometry" />
         </mxCell>
 
-        <!-- ===== USER (external) ===== -->
-        <mxCell id="user" value="ユーザー&#xa;(スマホ / PC)" style="shape=mxgraph.aws4.user;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=11;" vertex="1" parent="1">
-          <mxGeometry x="60" y="400" width="60" height="80" as="geometry" />
+        <!-- ===== USER ===== -->
+        <mxCell id="user" value="ユーザー&#xa;(スマホ / PC)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="60" y="280" width="130" height="60" as="geometry" />
         </mxCell>
 
-        <!-- ===== GITHUB ACTIONS (external) ===== -->
-        <mxCell id="github-box" value="GitHub Actions" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=13;fontStyle=1;arcSize=5;" vertex="1" parent="1">
-          <mxGeometry x="40" y="100" width="160" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="github-ci" value="ci.yml&#xa;(RuboCop + RSpec)" style="text;html=1;fontSize=10;align=center;" vertex="1" parent="1">
-          <mxGeometry x="40" y="155" width="160" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="github-deploy" value="deploy.yml&#xa;(ECR push → ECS deploy)" style="text;html=1;fontSize=10;align=center;" vertex="1" parent="1">
-          <mxGeometry x="40" y="185" width="160" height="30" as="geometry" />
+        <!-- ===== AMPLIFY ===== -->
+        <mxCell id="amplify" value="AWS Amplify Hosting&#xa;React + TypeScript (PWA)&#xa;Vite ビルド" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="270" y="260" width="180" height="70" as="geometry" />
         </mxCell>
 
-        <!-- ===== AWS CLOUD BOUNDARY ===== -->
-        <mxCell id="aws-cloud" value="AWS Cloud (ap-northeast-1)" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_aws_cloud_alt;strokeColor=#232F3E;fillColor=#FFFFFF;verticalAlign=top;align=center;spacingTop=25;fontStyle=1;fontSize=13;grStroke=2;" vertex="1" parent="1">
-          <mxGeometry x="270" y="80" width="1310" height="990" as="geometry" />
+        <!-- ===== COGNITO ===== -->
+        <mxCell id="cognito" value="Amazon Cognito&#xa;User Pool&#xa;OAuth PKCE / Hosted UI" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="270" y="150" width="180" height="70" as="geometry" />
         </mxCell>
 
-        <!-- ===== ECR ===== -->
-        <mxCell id="ecr" value="Amazon ECR&#xa;(Railsイメージ)" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.ecr;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="310" y="120" width="60" height="60" as="geometry" />
+        <!-- ===== API GATEWAY ===== -->
+        <mxCell id="apigw" value="API Gateway (HTTP API)&#xa;JWT Authorizer (Cognito)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="540" y="270" width="190" height="60" as="geometry" />
         </mxCell>
 
-        <!-- ===== IAM Role ===== -->
-        <mxCell id="iam" value="IAM&#xa;(OIDC / Task Role)" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.role;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="430" y="120" width="60" height="60" as="geometry" />
+        <!-- ===== LAMBDA GROUP ===== -->
+        <mxCell id="lambda-group" value="Lambda Functions (Python 3.13)" style="swimlane;startSize=30;fillColor=#f5f5f5;strokeColor=#82b366;fontColor=#333333;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="820" y="130" width="220" height="450" as="geometry" />
         </mxCell>
 
-        <!-- ===== SSM ===== -->
-        <mxCell id="ssm" value="SSM Parameter Store&#xa;(AUTH_USERNAME&#xa;AUTH_PASSWORD)" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.systems_manager_parameter_store;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="550" y="110" width="60" height="60" as="geometry" />
+        <mxCell id="lambda-create" value="create_record&#xa;POST /records" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="lambda-group">
+          <mxGeometry x="20" y="45" width="180" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="lambda-get" value="get_latest&#xa;GET /records/latest" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="lambda-group">
+          <mxGeometry x="20" y="100" width="180" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="lambda-delete" value="delete_record&#xa;DELETE /records/{id}" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="lambda-group">
+          <mxGeometry x="20" y="155" width="180" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="lambda-getconfig" value="get_item_config&#xa;GET /item-configs" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="lambda-group">
+          <mxGeometry x="20" y="210" width="180" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="lambda-saveconfig" value="save_item_config&#xa;PUT /item-configs" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="lambda-group">
+          <mxGeometry x="20" y="265" width="180" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="lambda-subscribe" value="push_subscribe&#xa;POST/DELETE /push/subscriptions" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="lambda-group">
+          <mxGeometry x="20" y="320" width="180" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="lambda-notify" value="push_notify&#xa;Web Push 送信" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="lambda-group">
+          <mxGeometry x="20" y="390" width="180" height="40" as="geometry" />
         </mxCell>
 
-        <!-- ===== CloudWatch ===== -->
-        <mxCell id="cloudwatch" value="CloudWatch Logs&#xa;(ECSコンテナログ)" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudwatch;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="670" y="120" width="60" height="60" as="geometry" />
+        <!-- ===== EventBridge ===== -->
+        <mxCell id="eventbridge" value="EventBridge Scheduler&#xa;毎日 21:00 JST" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="560" y="510" width="170" height="55" as="geometry" />
         </mxCell>
 
-        <!-- ===== VPC ===== -->
-        <mxCell id="vpc" value="VPC (10.0.0.0/16)" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_vpc;strokeColor=#8C4FFF;fillColor=#F4F0FF;verticalAlign=top;align=center;spacingTop=25;fontStyle=1;fontSize=12;" vertex="1" parent="1">
-          <mxGeometry x="290" y="240" width="880" height="700" as="geometry" />
+        <!-- ===== KINESIS FIREHOSE ===== -->
+        <mxCell id="firehose" value="Kinesis Firehose&#xa;Delivery Stream" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="160" width="150" height="55" as="geometry" />
         </mxCell>
 
-        <!-- ===== PUBLIC SUBNET ===== -->
-        <mxCell id="public-subnet" value="パブリックサブネット&#xa;(10.0.0.0/24 / AZ-a)" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_public_subnet;strokeColor=#147EBA;fillColor=#E6F2F8;verticalAlign=top;align=center;spacingTop=25;fontSize=11;" vertex="1" parent="1">
-          <mxGeometry x="310" y="290" width="390" height="280" as="geometry" />
+        <!-- ===== S3 TABLES (Iceberg) ===== -->
+        <mxCell id="s3tables" value="S3 Tables&#xa;Apache Iceberg" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="270" width="150" height="55" as="geometry" />
         </mxCell>
 
-        <!-- IGW -->
-        <mxCell id="igw" value="Internet&#xa;Gateway" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.internet_gateway;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="340" y="340" width="60" height="60" as="geometry" />
+        <!-- ===== GLUE ===== -->
+        <mxCell id="glue" value="AWS Glue&#xa;Data Catalog&#xa;health_records テーブル" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="380" width="150" height="65" as="geometry" />
         </mxCell>
 
-        <!-- NAT GW -->
-        <mxCell id="natgw" value="NAT Gateway" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.nat_gateway;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="460" y="340" width="60" height="60" as="geometry" />
+        <!-- ===== ATHENA ===== -->
+        <mxCell id="athena" value="Amazon Athena&#xa;SELECT / DELETE クエリ" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="500" width="150" height="55" as="geometry" />
         </mxCell>
 
-        <!-- ALB -->
-        <mxCell id="alb" value="ALB&#xa;(HTTPS:443)" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.application_load_balancer;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="590" y="340" width="60" height="60" as="geometry" />
+        <!-- ===== S3 (results/backup) ===== -->
+        <mxCell id="s3results" value="Amazon S3&#xa;クエリ結果 / バックアップ" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="610" width="150" height="55" as="geometry" />
         </mxCell>
 
-        <!-- ===== PRIVATE SUBNET ===== -->
-        <mxCell id="private-subnet" value="プライベートサブネット&#xa;(10.0.1.0/24 / AZ-a)" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_private_subnet;strokeColor=#3F8624;fillColor=#EFF7EC;verticalAlign=top;align=center;spacingTop=25;fontSize=11;" vertex="1" parent="1">
-          <mxGeometry x="310" y="620" width="390" height="280" as="geometry" />
+        <!-- ===== DYNAMODB ===== -->
+        <mxCell id="dynamodb" value="DynamoDB&#xa;item-configs テーブル&#xa;push-subscriptions テーブル" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="820" y="640" width="200" height="70" as="geometry" />
         </mxCell>
 
-        <!-- ECS Cluster -->
-        <mxCell id="ecs-cluster" value="ECS Cluster" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_ecs_cluster;strokeColor=#E86817;fillColor=#FEF1E8;verticalAlign=top;align=center;spacingTop=25;fontSize=11;" vertex="1" parent="1">
-          <mxGeometry x="330" y="670" width="350" height="200" as="geometry" />
+        <!-- ===== CLOUDWATCH ===== -->
+        <mxCell id="cloudwatch" value="CloudWatch Logs&#xa;Lambda 実行ログ" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="720" width="150" height="50" as="geometry" />
         </mxCell>
 
-        <!-- ECS Fargate Task -->
-        <mxCell id="ecs-task" value="ECS Fargate Task&#xa;Rails 8.1 / Ruby 3.3&#xa;(Port 3000)" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.ecs;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="450" y="720" width="60" height="60" as="geometry" />
+        <!-- ===== GITHUB ACTIONS (CI/CD) ===== -->
+        <mxCell id="github-group" value="GitHub Actions (CI/CD)" style="swimlane;startSize=30;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="60" y="830" width="620" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="ci" value="ci.yml&#xa;Lambda テスト + フロントエンドビルド" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="github-group">
+          <mxGeometry x="20" y="40" width="180" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="deploy" value="deploy.yml&#xa;Lambda ZIP → S3 → tf apply → Amplify" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="github-group">
+          <mxGeometry x="220" y="40" width="180" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="tf-workflow" value="terraform.yml&#xa;Plan (PR) / Apply (main push)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="github-group">
+          <mxGeometry x="420" y="40" width="180" height="60" as="geometry" />
         </mxCell>
 
-        <!-- ===== DATA LAKE GROUP ===== -->
-        <mxCell id="datalake-group" value="データレイク / 分析基盤" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=13;fontStyle=1;arcSize=3;verticalAlign=top;spacingTop=5;" vertex="1" parent="1">
-          <mxGeometry x="1000" y="260" width="540" height="650" as="geometry" />
+        <!-- ===== IAM OIDC ===== -->
+        <mxCell id="iam" value="IAM Role (OIDC)&#xa;github_actions ロール" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="270" y="870" width="160" height="55" as="geometry" />
         </mxCell>
 
-        <!-- S3 -->
-        <mxCell id="s3" value="Amazon S3&#xa;health-logger-prod&#xa;health_logs/dt=YYYY-MM-DD/&#xa;{uuid}.jsonl" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="1040" y="320" width="60" height="60" as="geometry" />
+        <!-- ===== S3 Artifacts ===== -->
+        <mxCell id="s3-artifacts" value="S3&#xa;Lambda Artifacts" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="470" y="870" width="140" height="55" as="geometry" />
         </mxCell>
 
-        <!-- Glue Crawler -->
-        <mxCell id="glue-crawler" value="Glue Crawler&#xa;(スキーマ自動検出)" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.glue_crawlers;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="1160" y="320" width="60" height="60" as="geometry" />
-        </mxCell>
-
-        <!-- Glue Catalog -->
-        <mxCell id="glue-catalog" value="Glue Data Catalog&#xa;(health_records テーブル)" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.glue_data_catalog;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="1280" y="320" width="60" height="60" as="geometry" />
-        </mxCell>
-
-        <!-- Athena -->
-        <mxCell id="athena" value="Amazon Athena&#xa;(SQLクエリ分析)" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.athena;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="1400" y="320" width="60" height="60" as="geometry" />
-        </mxCell>
-
-        <!-- Athena Result S3 -->
-        <mxCell id="athena-s3" value="S3 (クエリ結果)" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="1400" y="460" width="60" height="60" as="geometry" />
-        </mxCell>
-
-        <!-- EventBridge -->
-        <mxCell id="eventbridge" value="EventBridge Scheduler&#xa;(毎時トリガー)" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.event_bridge;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="1040" y="480" width="60" height="60" as="geometry" />
-        </mxCell>
-
-        <!-- Export ECS Task -->
-        <mxCell id="export-task" value="ECS RunTask&#xa;(ExportHealthRecordsJob)" style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.ecs;labelBackgroundColor=none;sketch=0;fontStyle=1;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="1160" y="480" width="60" height="60" as="geometry" />
-        </mxCell>
-
-        <!-- ===== LOCAL DEV BOX ===== -->
-        <mxCell id="local-dev" value="ローカル開発環境 (Docker Compose)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;fontStyle=1;arcSize=3;verticalAlign=top;spacingTop=5;" vertex="1" parent="1">
-          <mxGeometry x="290" y="970" width="470" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="local-web" value="web (Rails :3000)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="300" y="1005" width="140" height="35" as="geometry" />
-        </mxCell>
-        <mxCell id="local-minio" value="MinIO :9000 (S3互換)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="460" y="1005" width="140" height="35" as="geometry" />
-        </mxCell>
-        <mxCell id="local-console" value="MinIO Console :9001" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
-          <mxGeometry x="615" y="1005" width="135" height="35" as="geometry" />
-        </mxCell>
-
-        <!-- ===== LEGEND ===== -->
-        <mxCell id="legend-box" value="凡例" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;fontStyle=1;arcSize=5;verticalAlign=top;spacingTop=5;" vertex="1" parent="1">
-          <mxGeometry x="1110" y="860" width="250" height="180" as="geometry" />
-        </mxCell>
-        <mxCell id="leg1" value="" style="endArrow=block;endFill=1;strokeColor=#0000FF;" edge="1" parent="1">
-          <mxGeometry x="1125" y="900" width="60" height="10" as="geometry" relative="0">
-            <Array as="points"><mxPoint x="1185" y="905"/></Array>
-            <mxPoint x="1125" y="905" as="sourcePoint"/>
-            <mxPoint x="1185" y="905" as="targetPoint"/>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="leg1-label" value="HTTPリクエスト / レスポンス" style="text;html=1;fontSize=10;align=left;" vertex="1" parent="1">
-          <mxGeometry x="1195" y="895" width="155" height="20" as="geometry" />
-        </mxCell>
-        <mxCell id="leg2" value="" style="endArrow=block;endFill=1;strokeColor=#FF8000;dashed=1;" edge="1" parent="1">
-          <mxGeometry x="1125" y="930" width="60" height="10" as="geometry" relative="0">
-            <mxPoint x="1125" y="935" as="sourcePoint"/>
-            <mxPoint x="1185" y="935" as="targetPoint"/>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="leg2-label" value="CI/CDフロー" style="text;html=1;fontSize=10;align=left;" vertex="1" parent="1">
-          <mxGeometry x="1195" y="925" width="155" height="20" as="geometry" />
-        </mxCell>
-        <mxCell id="leg3" value="" style="endArrow=block;endFill=1;strokeColor=#007700;dashed=1;" edge="1" parent="1">
-          <mxGeometry x="1125" y="960" width="60" height="10" as="geometry" relative="0">
-            <mxPoint x="1125" y="965" as="sourcePoint"/>
-            <mxPoint x="1185" y="965" as="targetPoint"/>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="leg3-label" value="データフロー (S3書き込み)" style="text;html=1;fontSize=10;align=left;" vertex="1" parent="1">
-          <mxGeometry x="1195" y="955" width="155" height="20" as="geometry" />
-        </mxCell>
-        <mxCell id="leg4" value="" style="endArrow=block;endFill=1;strokeColor=#AA00AA;dashed=1;" edge="1" parent="1">
-          <mxGeometry x="1125" y="990" width="60" height="10" as="geometry" relative="0">
-            <mxPoint x="1125" y="995" as="sourcePoint"/>
-            <mxPoint x="1185" y="995" as="targetPoint"/>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="leg4-label" value="バッチ / スケジュール" style="text;html=1;fontSize=10;align=left;" vertex="1" parent="1">
-          <mxGeometry x="1195" y="985" width="155" height="20" as="geometry" />
-        </mxCell>
-        <mxCell id="leg5" value="" style="endArrow=block;endFill=1;strokeColor=#555555;" edge="1" parent="1">
-          <mxGeometry x="1125" y="1020" width="60" height="10" as="geometry" relative="0">
-            <mxPoint x="1125" y="1025" as="sourcePoint"/>
-            <mxPoint x="1185" y="1025" as="targetPoint"/>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="leg5-label" value="クエリ / 参照" style="text;html=1;fontSize=10;align=left;" vertex="1" parent="1">
-          <mxGeometry x="1195" y="1015" width="155" height="20" as="geometry" />
+        <!-- ===== S3 tfstate ===== -->
+        <mxCell id="s3-tfstate" value="S3 + DynamoDB&#xa;Terraform State / Lock" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="650" y="870" width="150" height="55" as="geometry" />
         </mxCell>
 
         <!-- ===== EDGES ===== -->
 
-        <!-- User → ALB (HTTPS) -->
-        <mxCell id="e-user-alb" value="HTTPS (Basic Auth)" style="endArrow=block;endFill=1;strokeColor=#0000FF;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="user" target="alb" parent="1">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="170" y="440"/>
-              <mxPoint x="170" y="370"/>
-            </Array>
-          </mxGeometry>
-        </mxCell>
-
-        <!-- ALB → ECS Task (HTTP:3000) -->
-        <mxCell id="e-alb-ecs" value="HTTP :3000" style="endArrow=block;endFill=1;strokeColor=#0000FF;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="alb" target="ecs-task" parent="1">
+        <!-- User ↔ Amplify (HTTPS) -->
+        <mxCell id="e-user-amplify" value="HTTPS" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#0000FF;" edge="1" source="user" target="amplify" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- ECS Task → S3 (JSON Lines write) -->
-        <mxCell id="e-ecs-s3" value="PUT JSON Lines" style="endArrow=block;endFill=1;strokeColor=#007700;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="ecs-task" target="s3" parent="1">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="900" y="750"/>
-              <mxPoint x="900" y="350"/>
-            </Array>
-          </mxGeometry>
-        </mxCell>
-
-        <!-- ECS Task → CloudWatch -->
-        <mxCell id="e-ecs-cw" value="ログ送信" style="endArrow=block;endFill=1;strokeColor=#555555;dashed=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" source="ecs-task" target="cloudwatch" parent="1">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="480" y="710"/>
-              <mxPoint x="700" y="710"/>
-              <mxPoint x="700" y="190"/>
-            </Array>
-          </mxGeometry>
-        </mxCell>
-
-        <!-- ECS Task → SSM (param lookup) -->
-        <mxCell id="e-ecs-ssm" value="シークレット取得" style="endArrow=block;endFill=1;strokeColor=#555555;dashed=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" source="ecs-task" target="ssm" parent="1">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="480" y="660"/>
-              <mxPoint x="580" y="660"/>
-              <mxPoint x="580" y="180"/>
-            </Array>
-          </mxGeometry>
-        </mxCell>
-
-        <!-- ECR → ECS (image pull) -->
-        <mxCell id="e-ecr-ecs" value="イメージPull" style="endArrow=block;endFill=1;strokeColor=#FF8000;dashed=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=0;" edge="1" source="ecr" target="ecs-task" parent="1">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="340" y="230"/>
-              <mxPoint x="340" y="660"/>
-              <mxPoint x="450" y="660"/>
-            </Array>
-          </mxGeometry>
-        </mxCell>
-
-        <!-- NAT GW → IGW (outbound) -->
-        <mxCell id="e-nat-igw" value="" style="endArrow=open;endFill=0;strokeColor=#147EBA;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="natgw" target="igw" parent="1">
+        <!-- User ↔ Cognito (OAuth) -->
+        <mxCell id="e-user-cognito" value="OAuth PKCE" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d6b656;dashed=1;" edge="1" source="user" target="cognito" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- S3 → Glue Crawler -->
-        <mxCell id="e-s3-crawler" value="クロール" style="endArrow=block;endFill=1;strokeColor=#555555;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="s3" target="glue-crawler" parent="1">
+        <!-- Amplify → API Gateway -->
+        <mxCell id="e-amplify-apigw" value="HTTPS + JWT" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#0000FF;" edge="1" source="amplify" target="apigw" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- Glue Crawler → Glue Catalog -->
-        <mxCell id="e-crawler-catalog" value="スキーマ登録" style="endArrow=block;endFill=1;strokeColor=#555555;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="glue-crawler" target="glue-catalog" parent="1">
+        <!-- Cognito → API Gateway (JWT 検証) -->
+        <mxCell id="e-cognito-apigw" value="JWT 検証" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d6b656;dashed=1;" edge="1" source="cognito" target="apigw" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- Glue Catalog → Athena -->
-        <mxCell id="e-catalog-athena" value="テーブル参照" style="endArrow=block;endFill=1;strokeColor=#555555;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="glue-catalog" target="athena" parent="1">
+        <!-- API Gateway → Lambda group -->
+        <mxCell id="e-apigw-lambda" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#b85450;" edge="1" source="apigw" target="lambda-group" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- Athena → S3 (reads from) -->
-        <mxCell id="e-athena-s3read" value="S3 SELECT" style="endArrow=block;endFill=1;strokeColor=#555555;dashed=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" edge="1" source="athena" target="s3" parent="1">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="1395" y="350"/>
-              <mxPoint x="1100" y="350"/>
-            </Array>
-          </mxGeometry>
-        </mxCell>
-
-        <!-- Athena → S3 result -->
-        <mxCell id="e-athena-result" value="クエリ結果保存" style="endArrow=block;endFill=1;strokeColor=#555555;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="athena" target="athena-s3" parent="1">
+        <!-- create_record → Firehose -->
+        <mxCell id="e-create-firehose" value="put_record" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;" edge="1" source="lambda-create" target="firehose" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- EventBridge → ECS Export Task -->
-        <mxCell id="e-eb-export" value="毎時トリガー" style="endArrow=block;endFill=1;strokeColor=#AA00AA;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="eventbridge" target="export-task" parent="1">
+        <!-- Firehose → S3 Tables -->
+        <mxCell id="e-firehose-s3tables" value="JSON Lines" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;" edge="1" source="firehose" target="s3tables" parent="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- Export ECS Task → S3 -->
-        <mxCell id="e-export-s3" value="JSON Lines書き込み" style="endArrow=block;endFill=1;strokeColor=#007700;dashed=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" source="export-task" target="s3" parent="1">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="1100" y="510"/>
-              <mxPoint x="1070" y="510"/>
-              <mxPoint x="1070" y="390"/>
-            </Array>
-          </mxGeometry>
+        <!-- S3 Tables ↔ Glue -->
+        <mxCell id="e-s3tables-glue" value="Iceberg カタログ" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d6b656;" edge="1" source="s3tables" target="glue" parent="1">
+          <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- GitHub → ECR (docker push) -->
-        <mxCell id="e-gh-ecr" value="docker push" style="endArrow=block;endFill=1;strokeColor=#FF8000;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="github-box" target="ecr" parent="1">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="260" y="125"/>
-              <mxPoint x="260" y="150"/>
-            </Array>
-          </mxGeometry>
+        <!-- Glue ↔ Athena -->
+        <mxCell id="e-glue-athena" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#9673a6;" edge="1" source="glue" target="athena" parent="1">
+          <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- GitHub → IAM (OIDC) -->
-        <mxCell id="e-gh-iam" value="OIDC AssumeRole" style="endArrow=block;endFill=1;strokeColor=#FF8000;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;" edge="1" source="github-box" target="iam" parent="1">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="260" y="125"/>
-              <mxPoint x="260" y="200"/>
-              <mxPoint x="460" y="200"/>
-            </Array>
-          </mxGeometry>
+        <!-- get_latest → Athena -->
+        <mxCell id="e-get-athena" value="SELECT" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;" edge="1" source="lambda-get" target="athena" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- delete_record → Athena -->
+        <mxCell id="e-delete-athena" value="DELETE" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;" edge="1" source="lambda-delete" target="athena" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Athena → S3 results -->
+        <mxCell id="e-athena-s3" value="クエリ結果" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#9673a6;" edge="1" source="athena" target="s3results" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Firehose → S3 (backup) -->
+        <mxCell id="e-firehose-s3backup" value="バックアップ" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;dashed=1;" edge="1" source="firehose" target="s3results" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- EventBridge → push_notify -->
+        <mxCell id="e-eb-notify" value="cron 21:00 JST" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d6b656;" edge="1" source="eventbridge" target="lambda-notify" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- get_item_config / save_item_config / push_subscribe / push_notify → DynamoDB -->
+        <mxCell id="e-getconfig-ddb" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#b85450;" edge="1" source="lambda-getconfig" target="dynamodb" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-saveconfig-ddb" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#b85450;" edge="1" source="lambda-saveconfig" target="dynamodb" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-subscribe-ddb" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#b85450;" edge="1" source="lambda-subscribe" target="dynamodb" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e-notify-ddb" value="購読者取得" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#b85450;" edge="1" source="lambda-notify" target="dynamodb" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Lambda → CloudWatch -->
+        <mxCell id="e-lambda-cw" value="ログ" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#666666;dashed=1;" edge="1" source="lambda-group" target="cloudwatch" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- GitHub Actions → IAM (OIDC) -->
+        <mxCell id="e-gh-iam" value="OIDC AssumeRole" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#FF8000;dashed=1;" edge="1" source="github-group" target="iam" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- GitHub Actions → S3 Artifacts -->
+        <mxCell id="e-gh-s3artifacts" value="Lambda ZIP" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#FF8000;dashed=1;" edge="1" source="github-group" target="s3-artifacts" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- GitHub Actions → S3 tfstate -->
+        <mxCell id="e-gh-tfstate" value="tf state" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#FF8000;dashed=1;" edge="1" source="github-group" target="s3-tfstate" parent="1">
+          <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
       </root>


### PR DESCRIPTION
## 関連イシュー
なし（ドキュメント更新）

## 変更内容
- `docs/infrastructure.drawio` を古い ECS/Rails/VPC/ALB 構成から現在のサーバーレス構成に更新

### 新しい図に含まれる要素
- **フロントエンド**: Amplify Hosting (React+TS PWA)
- **認証**: Cognito User Pool (OAuth PKCE)
- **API**: API Gateway HTTP API + JWT Authorizer
- **Lambda (7関数)**: create_record, get_latest, delete_record, get_item_config, save_item_config, push_subscribe, push_notify
- **データ書き込み**: Kinesis Firehose → S3 Tables (Iceberg) ← Glue Catalog
- **クエリ**: Athena (SELECT / DELETE)
- **ストレージ**: DynamoDB (item-configs, push-subscriptions)
- **スケジューラ**: EventBridge Scheduler (毎日 21:00 JST → push_notify)
- **CI/CD**: GitHub Actions (ci.yml / deploy.yml / terraform.yml) + IAM OIDC + S3 Artifacts + S3 tfstate

## テスト確認
- [ ] draw.io でファイルを開いて図が正しく表示される

## レビュー観点
- 構成要素の漏れがないか
- 矢印の方向・ラベルが正しいか