### PR TITLE
feat: アイコンによる FLAGS/カスタム項目の UI 改善

### DIFF
--- a/frontend/src/components/HealthForm.tsx
+++ b/frontend/src/components/HealthForm.tsx
@@ -24,6 +24,15 @@ const FLAG_LABELS: Record<keyof typeof FLAGS, string> = {
   caffeine:    'カフェイン',
 }
 
+const FLAG_ICONS: Record<keyof typeof FLAGS, string> = {
+  poor_sleep:  '😴',
+  headache:    '🤕',
+  stomachache: '🤢',
+  exercise:    '🏃',
+  alcohol:     '🍺',
+  caffeine:    '☕',
+}
+
 type ToastVariant = 'success' | 'danger' | 'warning'
 interface ToastState { show: boolean; message: string; variant: ToastVariant }
 
@@ -192,7 +201,10 @@ export default function HealthForm({ formItems, eventItems }: Props) {
                   disabled={eventSending[item.item_id]}
                   style={{ whiteSpace: 'nowrap' }}
                 >
-                  {eventSending[item.item_id] ? '…' : `✓ ${item.label}${item.unit ? ` (${item.unit})` : ''}`}
+                  {eventSending[item.item_id]
+                    ? '…'
+                    : <>{item.icon ? item.icon : '✓'} {item.label}{item.unit ? ` (${item.unit})` : ''}</>
+                  }
                 </button>
               </div>
             ))}
@@ -230,21 +242,35 @@ export default function HealthForm({ formItems, eventItems }: Props) {
         {/* Flags */}
         <div className="mb-3">
           <label className="form-label">フラグ</label>
-          <div className="d-flex flex-wrap gap-3">
-            {(Object.entries(FLAGS) as [keyof typeof FLAGS, number][]).map(([key, bit]) => (
-              <div className="form-check" key={key}>
-                <input
-                  type="checkbox"
-                  className="form-check-input"
-                  id={`flag-${key}`}
-                  checked={(flags & bit) !== 0}
-                  onChange={() => toggleFlag(bit)}
-                />
-                <label className="form-check-label" htmlFor={`flag-${key}`}>
-                  {FLAG_LABELS[key]}
-                </label>
-              </div>
-            ))}
+          <div className="d-flex flex-wrap gap-2">
+            {(Object.entries(FLAGS) as [keyof typeof FLAGS, number][]).map(([key, bit]) => {
+              const active = (flags & bit) !== 0
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => toggleFlag(bit)}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: '2px',
+                    padding: '8px 12px',
+                    border: `2px solid ${active ? '#198754' : '#dee2e6'}`,
+                    borderRadius: '12px',
+                    background: active ? '#d1e7dd' : '#f8f9fa',
+                    cursor: 'pointer',
+                    minWidth: '64px',
+                    transition: 'all 0.15s',
+                  }}
+                >
+                  <span style={{ fontSize: '1.4rem', lineHeight: 1 }}>{FLAG_ICONS[key]}</span>
+                  <span style={{ fontSize: '0.7rem', color: active ? '#198754' : '#6c757d', fontWeight: active ? 600 : 400 }}>
+                    {FLAG_LABELS[key]}
+                  </span>
+                </button>
+              )
+            })}
           </div>
         </div>
 
@@ -264,6 +290,7 @@ export default function HealthForm({ formItems, eventItems }: Props) {
                       onChange={(e) => setCustomValue(item.item_id, e.target.checked)}
                     />
                     <label className="form-check-label" htmlFor={`custom-${item.item_id}`}>
+                      {item.icon && <span className="me-1">{item.icon}</span>}
                       {item.label}
                     </label>
                   </div>
@@ -271,7 +298,7 @@ export default function HealthForm({ formItems, eventItems }: Props) {
                 {(item.type === 'slider') && (
                   <div>
                     <label className="form-label d-flex justify-content-between">
-                      <span>{item.label}</span>
+                      <span>{item.icon && <span className="me-1">{item.icon}</span>}{item.label}</span>
                       <span className="badge bg-secondary">
                         {customValues[item.item_id] ?? item.min ?? 0}
                         {item.unit && ` ${item.unit}`}
@@ -289,7 +316,10 @@ export default function HealthForm({ formItems, eventItems }: Props) {
                 )}
                 {item.type === 'number' && (
                   <div>
-                    <label className="form-label">{item.label}</label>
+                    <label className="form-label">
+                      {item.icon && <span className="me-1">{item.icon}</span>}
+                      {item.label}
+                    </label>
                     <div className="input-group" style={{ maxWidth: '200px' }}>
                       <input
                         type="number"
@@ -306,7 +336,10 @@ export default function HealthForm({ formItems, eventItems }: Props) {
                 )}
                 {item.type === 'text' && (
                   <div>
-                    <label className="form-label">{item.label}</label>
+                    <label className="form-label">
+                      {item.icon && <span className="me-1">{item.icon}</span>}
+                      {item.label}
+                    </label>
                     <input
                       type="text"
                       className="form-control"

--- a/frontend/src/components/ItemConfigScreen.tsx
+++ b/frontend/src/components/ItemConfigScreen.tsx
@@ -1,6 +1,15 @@
 import { useState } from 'react'
 import type { ItemConfig, ItemMode, ItemType } from '../types'
 
+const ICON_OPTIONS = [
+  '😴', '💤', '🤕', '🤢', '😣', '🤧', '💊', '🌡️',
+  '🏃', '🚶', '🧘', '🏋️', '🚴', '🤸', '⚽', '🏊',
+  '🍺', '🍷', '🍸', '🍻', '☕', '🧃', '💧', '🍵',
+  '😊', '😔', '😤', '😰', '💪', '🧠', '❤️', '💔',
+  '🌙', '☀️', '🌿', '⚡', '🎯', '📝', '⏰', '🔥',
+  '🍎', '🥗', '🥦', '🍣', '🍜', '🍕', '🎂', '🍫',
+]
+
 const TYPE_OPTIONS: { value: ItemType; label: string }[] = [
   { value: 'checkbox', label: 'チェックボックス' },
   { value: 'number',   label: '数値入力' },
@@ -18,6 +27,7 @@ interface EditState {
   label:   string
   type:    ItemType
   mode:    ItemMode
+  icon:    string
   min:     string
   max:     string
   unit:    string
@@ -28,6 +38,7 @@ const emptyEdit = (): EditState => ({
   label:   '',
   type:    'checkbox',
   mode:    'event',
+  icon:    '',
   min:     '',
   max:     '',
   unit:    '',
@@ -52,6 +63,7 @@ export default function ItemConfigScreen({ configs, onSave, onClose }: Props) {
       label:   item.label,
       type:    item.type,
       mode:    item.mode,
+      icon:    item.icon ?? '',
       min:     item.min != null ? String(item.min) : '',
       max:     item.max != null ? String(item.max) : '',
       unit:    item.unit ?? '',
@@ -65,6 +77,7 @@ export default function ItemConfigScreen({ configs, onSave, onClose }: Props) {
       type:    edit.type,
       mode:    edit.mode,
       order:   0,
+      ...(edit.icon !== '' && { icon: edit.icon }),
       ...(edit.min !== '' && { min: Number(edit.min) }),
       ...(edit.max !== '' && { max: Number(edit.max) }),
       ...(edit.unit !== '' && { unit: edit.unit }),
@@ -125,7 +138,10 @@ export default function ItemConfigScreen({ configs, onSave, onClose }: Props) {
           <div key={item.item_id} className="card mb-2">
             <div className="card-body py-2 d-flex align-items-center gap-2">
               <div className="flex-grow-1">
-                <div className="fw-semibold">{item.label}</div>
+                <div className="fw-semibold">
+                  {item.icon && <span className="me-2" style={{ fontSize: '1.1rem' }}>{item.icon}</span>}
+                  {item.label}
+                </div>
                 <small className="text-muted">
                   {TYPE_OPTIONS.find((t) => t.value === item.type)?.label}
                   {' · '}
@@ -178,6 +194,49 @@ export default function ItemConfigScreen({ configs, onSave, onClose }: Props) {
                   placeholder="例: 水分補給, 筋トレ"
                   autoFocus
                 />
+              </div>
+              <div className="mb-2">
+                <label className="form-label fw-semibold">アイコン（任意）</label>
+                <div
+                  className="d-flex flex-wrap gap-1 p-2 border rounded"
+                  style={{ maxHeight: '120px', overflowY: 'auto' }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setEdit({ ...edit, icon: '' })}
+                    style={{
+                      width: '36px',
+                      height: '36px',
+                      border: `2px solid ${edit.icon === '' ? '#0d6efd' : '#dee2e6'}`,
+                      borderRadius: '6px',
+                      background: edit.icon === '' ? '#cfe2ff' : '#f8f9fa',
+                      cursor: 'pointer',
+                      fontSize: '0.65rem',
+                      color: '#6c757d',
+                    }}
+                  >
+                    なし
+                  </button>
+                  {ICON_OPTIONS.map((emoji) => (
+                    <button
+                      key={emoji}
+                      type="button"
+                      onClick={() => setEdit({ ...edit, icon: emoji })}
+                      style={{
+                        width: '36px',
+                        height: '36px',
+                        border: `2px solid ${edit.icon === emoji ? '#0d6efd' : '#dee2e6'}`,
+                        borderRadius: '6px',
+                        background: edit.icon === emoji ? '#cfe2ff' : '#f8f9fa',
+                        cursor: 'pointer',
+                        fontSize: '1.2rem',
+                        lineHeight: 1,
+                      }}
+                    >
+                      {emoji}
+                    </button>
+                  ))}
+                </div>
               </div>
               <div className="mb-2">
                 <label className="form-label fw-semibold">入力タイプ</label>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7,6 +7,7 @@ export interface ItemConfig {
   type:    ItemType
   mode:    ItemMode
   order:   number
+  icon?:   string
   min?:    number
   max?:    number
   unit?:   string


### PR DESCRIPTION
## 関連イシュー
Closes #26

## 変更内容
- FLAGS（睡眠不足・頭痛・腹痛・運動・アルコール・カフェイン）をアイコン付きトグルカードボタン形式に変更
  - ON 時: 緑背景・緑ボーダー、OFF 時: グレー
  - アイコン: 😴 🤕 🤢 🏃 🍺 ☕
- `ItemConfig` に `icon?: string` を追加（optional で後方互換あり）
- カスタム項目の追加・編集フォームに絵文字ピッカーを追加（48種類、スクロール対応）
- フォーム・クイックイベントボタンでカスタム項目のアイコンを表示

## テスト確認
- [x] `pytest lambda/ -v` → 33件 PASSED
- [x] `npx tsc --noEmit` → エラーなし
- [x] `npm run build` → 成功

## レビュー観点
- アイコンピッカーの絵文字ラインナップが適切か
- トグルボタンのスタイル（サイズ・色）が UI に合っているか