### PR TITLE
fix: GitHub ActionsロールにS3/Glue作成権限を追加

### DIFF
--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -260,6 +260,7 @@ module "env_data_ingest" {
   environment      = var.env
   lambda_s3_bucket = module.lambda.artifacts_bucket_name
   lambda_s3_key    = var.lambda_s3_keys["get_env_data"]
+  depends_on       = [aws_iam_role_policy.github_actions]
 }
 
 # ── Outputs ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 関連イシュー
Closes #34

## 変更内容
PR #33 マージ後の terraform apply が以下のエラーで失敗していたため修正。

- `s3:CreateBucket` が不許可 → S3バケット作成・設定系アクションを追加
- `glue:CreateDatabase` が不許可 → Glue DB 作成・削除アクションを追加

## 追加した権限

**S3:**
- `s3:CreateBucket`, `s3:DeleteBucket`
- `s3:PutBucketVersioning`, `s3:PutBucketPublicAccessBlock`
- `s3:PutEncryptionConfiguration`, `s3:PutLifecycleConfiguration`
- `s3:PutBucketTagging`

**Glue:**
- `glue:GetDatabases`, `glue:CreateDatabase`, `glue:DeleteDatabase`

## テスト確認
- [ ] terraform plan → エラーなし
- [ ] terraform apply → S3バケット・Glue DB 作成成功