### PR TITLE
fix: GitHub ActionsロールにEventBridge権限を追加

### DIFF
--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -231,6 +231,16 @@ resource "aws_iam_role_policy" "github_actions" {
         Resource = ["*"]
       },
       {
+        Effect = "Allow"
+        Action = [
+          "events:PutRule", "events:DeleteRule", "events:DescribeRule",
+          "events:ListRules", "events:TagResource", "events:UntagResource",
+          "events:ListTagsForResource", "events:PutTargets",
+          "events:RemoveTargets", "events:ListTargetsByRule",
+        ]
+        Resource = ["*"]
+      },
+      {
         Effect   = "Allow"
         Action   = ["amplify:GetApp", "amplify:GetBranch", "amplify:ListApps", "amplify:ListBranches", "amplify:UpdateApp", "amplify:UpdateBranch", "amplify:CreateBranch", "amplify:DeleteBranch"]
         Resource = ["*"]


### PR DESCRIPTION
## 関連イシュー
Closes #36

## 変更内容
PR #35 マージ後の terraform apply で `events:TagResource` が不足していたため失敗。
EventBridge ルール管理に必要な権限を追加。

追加した権限:
- `events:PutRule`, `events:DeleteRule`, `events:DescribeRule`
- `events:ListRules`, `events:TagResource`, `events:UntagResource`
- `events:ListTagsForResource`, `events:PutTargets`
- `events:RemoveTargets`, `events:ListTargetsByRule`

## 補足
S3・Glue の権限は PR #35 で適用済みのため、本 PR マージ後の apply で全リソースが作成される想定。

## テスト確認
- [ ] terraform plan → エラーなし
- [ ] terraform apply → S3バケット・Glue DB・EventBridge Rule 作成成功