### PR TITLE
fix: Air Quality API失敗時のフォールバック処理を追加

### DIFF
--- a/lambda/get_env_data/clients/open_meteo.py
+++ b/lambda/get_env_data/clients/open_meteo.py
@@ -92,18 +92,27 @@ class OpenMeteoClient(WeatherProvider):
             },
         )
 
-        # Fetch air quality data
-        aq_data = _fetch_with_retry(
-            AIR_QUALITY_API_URL,
-            {
-                "latitude": lat,
-                "longitude": lng,
-                "start_date": date_from,
-                "end_date": date_to,
-                "hourly": AIR_QUALITY_HOURLY_PARAMS,
-                "timezone": "Asia/Tokyo",
-            },
-        )
+        # Fetch air quality data (forecast API: supports only recent ~5 days via past_days)
+        # For historical backfill beyond 5 days, this API returns 400 → skip gracefully
+        try:
+            aq_data = _fetch_with_retry(
+                AIR_QUALITY_API_URL,
+                {
+                    "latitude": lat,
+                    "longitude": lng,
+                    "start_date": date_from,
+                    "end_date": date_to,
+                    "hourly": AIR_QUALITY_HOURLY_PARAMS,
+                    "timezone": "Asia/Tokyo",
+                },
+            )
+        except Exception as e:
+            logger.warning(
+                '{"level": "WARNING", "message": "Air quality API unavailable, skipping",'
+                ' "date_from": "%s", "date_to": "%s", "error": "%s"}',
+                date_from, date_to, str(e),
+            )
+            aq_data = {"hourly": {}}
 
         return self._merge_records(
             archive_data=archive_data,


### PR DESCRIPTION
## 変更内容
Open-Meteo の Air Quality API は `start_date`/`end_date` による過去データ取得（5日超）に対応していないため、バックフィル時に 400 エラーが発生していた。

AQ API が失敗した場合は WARNING ログを出力し、空のデータとして扱い気象データのみで処理を継続するように修正。

## 動作確認
- バックフィル（2026-02-11〜2026-03-10）: 672レコード / 28ファイルを S3 に保存確認済み
- 近日分（5日以内）は AQ データも含めて取得される