### PR TITLE
fix: Air Quality API取得失敗を防ぐためスケジュールを06:00 UTCに変更 (#40)

### DIFF
--- a/terraform/modules/env_data_ingest/main.tf
+++ b/terraform/modules/env_data_ingest/main.tf
@@ -109,8 +109,8 @@ resource "aws_iam_role_policy" "get_env_data" {
         Resource = ["arn:aws:athena:*:*:workgroup/primary"]
       },
       {
-        Effect = "Allow"
-        Action = ["s3:GetObject", "s3:PutObject"]
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject"]
         Resource = ["${aws_s3_bucket.env_data.arn}/athena-results/*"]
       },
     ]
@@ -148,7 +148,7 @@ resource "aws_lambda_function" "get_env_data" {
 
 resource "aws_cloudwatch_event_rule" "env_data_daily" {
   name                = "${local.name}-env-data-daily"
-  description         = "Trigger get_env_data Lambda daily at 10:00 JST (01:00 UTC)"
+  description         = "Trigger get_env_data Lambda daily at 15:00 JST (06:00 UTC)"
   schedule_expression = var.schedule_expression
 }
 

--- a/terraform/modules/env_data_ingest/variables.tf
+++ b/terraform/modules/env_data_ingest/variables.tf
@@ -33,6 +33,6 @@ variable "longitude" {
 
 variable "schedule_expression" {
   type        = string
-  default     = "cron(0 1 * * ? *)"
-  description = "EventBridge schedule expression (UTC). Default: 10:00 JST = 01:00 UTC"
+  default     = "cron(0 6 * * ? *)"
+  description = "EventBridge schedule expression (UTC). Default: 15:00 JST = 06:00 UTC"
 }


### PR DESCRIPTION
## 関連イシュー
Closes #40

## 変更内容
- EventBridge スケジュールを `cron(0 1 * * ? *)` → `cron(0 6 * * ? *)` に変更
  - 変更前: 01:00 UTC = 10:00 JST
  - 変更後: 06:00 UTC = 15:00 JST

## 背景
Air Quality API（open-meteo）は前日データが 01:00 UTC 時点では未準備で 400 を返す。
数時間後には同じリクエストが 200 で成功することを確認済み。
実行を遅らせることで pm2_5・花粉などの大気質データも null にならず取得できる。

## テスト確認
- [x] `terraform validate` → Success
- [x] Air Quality API に昨日の日付でリクエスト → 200 OK（実行時刻が遅ければ取得可能）