### PR TITLE
fix: PM2.5取得失敗 — スケジュールを15:00 UTCに変更

### DIFF
--- a/terraform/modules/env_data_ingest/main.tf
+++ b/terraform/modules/env_data_ingest/main.tf
@@ -148,7 +148,7 @@ resource "aws_lambda_function" "get_env_data" {
 
 resource "aws_cloudwatch_event_rule" "env_data_daily" {
   name                = "${local.name}-env-data-daily"
-  description         = "Trigger get_env_data Lambda daily at 15:00 JST (06:00 UTC)"
+  description         = "Trigger get_env_data Lambda daily at 00:00 JST (15:00 UTC) after CAMS air quality data is ready"
   schedule_expression = var.schedule_expression
 }
 

--- a/terraform/modules/env_data_ingest/variables.tf
+++ b/terraform/modules/env_data_ingest/variables.tf
@@ -33,6 +33,6 @@ variable "longitude" {
 
 variable "schedule_expression" {
   type        = string
-  default     = "cron(0 6 * * ? *)"
-  description = "EventBridge schedule expression (UTC). Default: 15:00 JST = 06:00 UTC"
+  default     = "cron(0 15 * * ? *)"
+  description = "EventBridge schedule expression (UTC). Default: 00:00 JST (next day) = 15:00 UTC (after CAMS data is ready)"
 }


### PR DESCRIPTION
## 関連イシュー
Closes #46

## 変更内容
- EventBridgeスケジュールを `cron(0 6 * * ? *)` → `cron(0 15 * * ? *)` に変更
  - 15:00 UTC = JST 00:00（日本時間深夜0時）

## 原因
CloudWatch Logsで確認:
- 01:00 UTC実行時: Air Quality API → 400エラー（データ未準備）
- 13:13 UTC手動テストでは正常にPM2.5値を取得できることを確認

Open-MeteoのCAMSモデルデータは12:00 UTC以降に前日分が確定するため、
15:00 UTCに実行することで確実に取得できる。

## テスト確認
- [x] terraform validate → 成功
- [x] terraform fmt → 差分なし