### PR TITLE
chore: Agent Teams 実験機能を有効化

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,6 +41,9 @@
       "Bash(aws s3 sync *)"
     ]
   },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
   "enabledMcpjsonServers": [
     "filesystem",
     "github",


### PR DESCRIPTION
## 変更内容
`.claude/settings.json` に以下を追加：
```json
"env": {
  "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
}
```

## 効果
- 複数の独立した Claude Code セッションが並列で協調作業できるようになる
- orchestrator がチームリードとして frontend / lambda / devops 等に作業を並列委譲できる
- 各メンバーが `SendMessage` で相互通信しながら進捗を調整する

## 前提条件
- Claude Code v2.1.32 以上
- `.claude/agents/` の各エージェント定義は既にフロントマター（name/description/tools）が揃っている

## 注意事項
- 実験機能のため `/resume` でのセッション再開時にメンバー復元不可
- VS Code 統合ターミナルでは split-pane 表示に制限あり