### PR TITLE
feat: ステータス管理セクションを追加（頭痛・腹痛・眠い・勤務中）

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,8 +40,9 @@ function AppContent() {
     setRecords((prev) => prev.filter((r) => r.id !== id))
   }
 
-  const formItems  = configs.filter((c) => c.mode === 'form').sort((a, b) => a.order - b.order)
-  const eventItems = configs.filter((c) => c.mode === 'event').sort((a, b) => a.order - b.order)
+  const formItems   = configs.filter((c) => c.mode === 'form').sort((a, b) => a.order - b.order)
+  const eventItems  = configs.filter((c) => c.mode === 'event').sort((a, b) => a.order - b.order)
+  const statusItems = configs.filter((c) => c.mode === 'status').sort((a, b) => a.order - b.order)
 
   // 最新の daily 記録を HealthForm に渡す（前回値表示用）
   const latestDailyRecord = records.find((r) => r.record_type === 'daily')
@@ -87,6 +88,7 @@ function AppContent() {
       <HealthForm
         formItems={formItems}
         eventItems={eventItems}
+        statusItems={statusItems}
         latestDailyRecord={latestDailyRecord}
       />
 

--- a/frontend/src/components/HealthForm.tsx
+++ b/frontend/src/components/HealthForm.tsx
@@ -7,12 +7,17 @@ import type { CustomFieldValue, HealthRecordInput, ItemConfig, LatestRecord } fr
 const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT as string
 
 const FLAG_ITEMS = [
-  { item_id: 'poor_sleep',  label: '睡眠不足',    icon: '😴' },
-  { item_id: 'headache',    label: '頭痛',        icon: '🤕' },
-  { item_id: 'stomachache', label: '腹痛',        icon: '🤢' },
-  { item_id: 'exercise',    label: '運動',        icon: '🏃' },
-  { item_id: 'alcohol',     label: 'アルコール', icon: '🍺' },
-  { item_id: 'caffeine',    label: 'カフェイン', icon: '☕' },
+  { item_id: 'poor_sleep', label: '睡眠不足',    icon: '😴' },
+  { item_id: 'exercise',   label: '運動',        icon: '🏃' },
+  { item_id: 'alcohol',    label: 'アルコール', icon: '🍺' },
+  { item_id: 'caffeine',   label: 'カフェイン', icon: '☕' },
+] as const
+
+const STATUS_ITEMS = [
+  { item_id: 'headache',    label: '頭痛',   icon: '🤕' },
+  { item_id: 'stomachache', label: '腹痛',   icon: '🤢' },
+  { item_id: 'sleepy',      label: '眠い',   icon: '😪' },
+  { item_id: 'working',     label: '勤務中', icon: '💼' },
 ] as const
 
 /** スライダー各項目の accent-color */
@@ -41,12 +46,13 @@ type ToastVariant = 'success' | 'danger' | 'warning'
 interface ToastState { show: boolean; message: string; variant: ToastVariant }
 
 interface Props {
-  formItems:  ItemConfig[]
-  eventItems: ItemConfig[]
+  formItems:    ItemConfig[]
+  eventItems:   ItemConfig[]
+  statusItems:  ItemConfig[]
   latestDailyRecord?: LatestRecord
 }
 
-export default function HealthForm({ formItems, eventItems, latestDailyRecord }: Props) {
+export default function HealthForm({ formItems, eventItems, statusItems, latestDailyRecord }: Props) {
   const { token } = useAuth()
   const { enqueue, flush } = useOfflineQueue(API_ENDPOINT)
 
@@ -173,7 +179,28 @@ export default function HealthForm({ formItems, eventItems, latestDailyRecord }:
     setEventSending((s) => ({ ...s, [item.item_id]: false }))
   }
 
-  const handleQuickEvent = async (item: ItemConfig) => {
+  const sendStatusEvent = async (item: typeof STATUS_ITEMS[number]) => {
+    if (!token) return
+    setEventSending((s) => ({ ...s, [item.item_id]: true }))
+    const record: HealthRecordInput = {
+      record_type:   'status',
+      flags:         0,
+      note:          '',
+      recorded_at:   getRecordedAtISO(),
+      timezone:      Intl.DateTimeFormat().resolvedOptions().timeZone,
+      device_id:     navigator.userAgent.slice(0, 100),
+      app_version:   '1.0.0',
+      custom_fields: [{ item_id: item.item_id, label: item.label, type: 'checkbox', value: true }],
+    }
+    const ok = await submitRecord(record)
+    if (ok) {
+      showToast(`${item.label} を記録しました`, 'success')
+      flush(token).catch(() => {})
+    }
+    setEventSending((s) => ({ ...s, [item.item_id]: false }))
+  }
+
+  const handleQuickEvent = async (item: ItemConfig, recordType: 'event' | 'status' = 'event') => {
     if (!token) return
     let value: number | boolean | string
     if (item.type === 'checkbox') {
@@ -188,7 +215,7 @@ export default function HealthForm({ formItems, eventItems, latestDailyRecord }:
 
     setEventSending((s) => ({ ...s, [item.item_id]: true }))
     const record: HealthRecordInput = {
-      record_type:   'event',
+      record_type:   recordType,
       flags:         0,
       note:          '',
       recorded_at:   getRecordedAtISO(),   // ← 選択日時を使用
@@ -254,9 +281,72 @@ export default function HealthForm({ formItems, eventItems, latestDailyRecord }:
         </div>
         {!isNowSelected && (
           <p className="mb-0 mt-1 text-warning-emphasis" style={{ fontSize: '0.72rem' }}>
-            ※ クイックイベント・体調記録ともにこの日時で登録されます
+            ※ ステータス・クイックイベント・体調記録ともにこの日時で登録されます
           </p>
         )}
+      </div>
+
+      {/* ── Status (ongoing conditions) ───────────────────────── */}
+      <div className="mb-4">
+        <h2 className="h6 text-muted mb-2">ステータス</h2>
+        <div className="d-flex flex-wrap gap-2">
+          {STATUS_ITEMS.map((item) => (
+            <button
+              key={item.item_id}
+              type="button"
+              className="btn btn-outline-warning"
+              onClick={() => sendStatusEvent(item)}
+              disabled={eventSending[item.item_id]}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: '2px',
+                padding: '8px 12px',
+                minWidth: '64px',
+              }}
+            >
+              {eventSending[item.item_id] ? (
+                <span className="spinner-border spinner-border-sm" role="status" />
+              ) : (
+                <>
+                  <span style={{ fontSize: '1.4rem', lineHeight: 1 }}>{item.icon}</span>
+                  <span style={{ fontSize: '0.7rem' }}>{item.label}</span>
+                </>
+              )}
+            </button>
+          ))}
+
+          {/* カスタムステータス項目 */}
+          {statusItems
+            .filter((item) => item.type === 'checkbox')
+            .map((item) => (
+              <button
+                key={item.item_id}
+                type="button"
+                className="btn btn-outline-warning"
+                onClick={() => handleQuickEvent(item, 'status')}
+                disabled={eventSending[item.item_id]}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: '2px',
+                  padding: '8px 12px',
+                  minWidth: '64px',
+                }}
+              >
+                {eventSending[item.item_id] ? (
+                  <span className="spinner-border spinner-border-sm" role="status" />
+                ) : (
+                  <>
+                    <span style={{ fontSize: '1.4rem', lineHeight: 1 }}>{item.icon ?? '●'}</span>
+                    <span style={{ fontSize: '0.7rem' }}>{item.label}</span>
+                  </>
+                )}
+              </button>
+            ))}
+        </div>
       </div>
 
       {/* ── Quick Events (flags + custom event items) ──────────── */}

--- a/frontend/src/components/ItemConfigScreen.tsx
+++ b/frontend/src/components/ItemConfigScreen.tsx
@@ -18,8 +18,9 @@ const TYPE_OPTIONS: { value: ItemType; label: string }[] = [
 ]
 
 const MODE_OPTIONS: { value: ItemMode; label: string }[] = [
-  { value: 'event', label: 'クイックイベント（即時記録）' },
-  { value: 'form',  label: '日次フォームに追加' },
+  { value: 'status', label: 'ステータス（状態管理）' },
+  { value: 'event',  label: 'クイックイベント（即時記録）' },
+  { value: 'form',   label: '日次フォームに追加' },
 ]
 
 interface EditState {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,5 +1,5 @@
 export type ItemType = 'slider' | 'checkbox' | 'number' | 'text'
-export type ItemMode = 'form' | 'event'
+export type ItemMode = 'form' | 'event' | 'status'
 
 export interface ItemConfig {
   item_id: string
@@ -21,7 +21,7 @@ export interface CustomFieldValue {
 }
 
 export interface HealthRecordInput {
-  record_type:      'daily' | 'event'
+  record_type:      'daily' | 'event' | 'status'
   fatigue_score?:   number
   mood_score?:      number
   motivation_score?: number

--- a/lambda/create_record/models.py
+++ b/lambda/create_record/models.py
@@ -11,7 +11,7 @@ class CustomFieldValue(BaseModel):
 
 
 class HealthRecordInput(BaseModel):
-    record_type:      Literal["daily", "event"] = Field("daily")
+    record_type:      Literal["daily", "event", "status"] = Field("daily")
     fatigue_score:    Optional[int] = Field(None, ge=0, le=100)
     mood_score:       Optional[int] = Field(None, ge=0, le=100)
     motivation_score: Optional[int] = Field(None, ge=0, le=100)

--- a/lambda/create_record/test_handler.py
+++ b/lambda/create_record/test_handler.py
@@ -27,6 +27,17 @@ def test_valid_record():
     assert rec.custom_fields == []
 
 
+def test_status_record():
+    rec = HealthRecordInput(
+        record_type="status",
+        recorded_at="2024-01-01T10:30:00Z",
+        custom_fields=[{"item_id": "headache", "label": "頭痛", "type": "checkbox", "value": True}],
+    )
+    assert rec.record_type == "status"
+    assert rec.fatigue_score is None
+    assert rec.custom_fields[0].item_id == "headache"
+
+
 def test_event_record_no_scores():
     rec = HealthRecordInput(
         record_type="event",


### PR DESCRIPTION
## 関連イシュー
Closes #62

## 変更内容
- 新しい「ステータス」セクションを HealthForm に追加（クイックイベントの上に表示）
- 頭痛🤕・腹痛🤢をクイックイベントから **ステータス** に移動
- 眠い😪・勤務中💼 を新規ステータス項目として追加
- ステータスボタンは `btn-outline-warning`（黄色系）でクイックイベントと視覚的に区別
- `record_type: 'status'` を新設し Lambda・型定義に反映
- ItemConfigScreen にカスタムステータス項目を追加できる選択肢を追加
- `FLAG_ITEMS` は睡眠不足・運動・アルコール・カフェインのみに整理

## テスト確認
- [x] `pytest lambda/create_record/ lambda/get_latest/ -v` → 19 PASSED
- [x] `npx tsc --noEmit` → エラーなし

## レビュー観点
- ステータスボタンのビジュアル（btn-outline-warning）が意図通りか
- `record_type: 'status'` を追加したことで Athena クエリ側の影響がないか確認