### PR TITLE
feat: dbt + dbt-mcp Docker sidecar 構成を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,12 @@ lambda/*/typing_extensions.py
 .terraform/
 .terraform.lock.hcl
 
+# dbt
+data/dbt/.env
+data/dbt/profiles/profiles.yml
+data/dbt/target/
+data/dbt/dbt_packages/
+data/dbt/logs/
+
 # OS
 .DS_Store

--- a/data/dbt/.env.example
+++ b/data/dbt/.env.example
@@ -1,0 +1,37 @@
+# =============================================================================
+# dbt / dbt-mcp Docker 環境変数
+#
+# 使い方:
+#   cp data/dbt/.env.example data/dbt/.env
+#   # .env を編集して実際の値を設定
+#   docker compose -f docker-compose.dbt.yml up -d
+#
+# ⚠️ .env は .gitignore に含まれています。シークレット値をコミットしないでください。
+# =============================================================================
+
+# --- dbt アダプター設定 ---
+# DWH を切り替える場合はここを変更する
+# 選択肢: dbt-athena-community / dbt-postgres / dbt-bigquery / dbt-snowflake / dbt-duckdb
+DBT_ADAPTER=dbt-athena-community
+DBT_ADAPTER_VERSION=1.9.4
+DBT_CORE_VERSION=1.10.5
+DBT_MCP_VERSION=1.10.0
+
+# --- MCP サーバー設定 ---
+# MCP_TRANSPORT: streamable-http (推奨) / sse / stdio
+MCP_TRANSPORT=streamable-http
+MCP_HOST=0.0.0.0
+MCP_PORT=8811
+
+# --- AWS 認証（Athena アダプター使用時）---
+# 本番環境では IAM ロール（AWS_PROFILE）を推奨
+# ローカル開発では以下のいずれかを設定する:
+#
+# [方法1] AWS プロファイルを使う（推奨）
+AWS_PROFILE=default
+AWS_REGION=ap-northeast-1
+#
+# [方法2] アクセスキーを直接指定（非推奨・漏洩リスクあり）
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_SESSION_TOKEN=   # 一時認証情報の場合のみ

--- a/data/dbt/profiles/profiles.yml.example
+++ b/data/dbt/profiles/profiles.yml.example
@@ -1,0 +1,68 @@
+# =============================================================================
+# dbt profiles.yml サンプル
+#
+# 使い方:
+#   cp data/dbt/profiles/profiles.yml.example data/dbt/profiles/profiles.yml
+#   # profiles.yml を編集して実際の接続情報を設定
+#
+# ⚠️ profiles.yml は .gitignore に含まれています。認証情報をコミットしないでください。
+#
+# コンテナ内のパス: /root/.dbt/profiles.yml
+#   → DBT_PROFILES_DIR=/root/.dbt で参照される
+# =============================================================================
+
+health_logger:
+  target: dev
+  outputs:
+
+    # =========================================================================
+    # Athena（このプロジェクトのデフォルト）
+    # =========================================================================
+    dev:
+      type: athena
+      # Glue データベース名 = dbt の schema として扱われる
+      database: health_logger_env_prod
+      schema: health_logger_env_prod
+      # Athena クエリ結果の出力先 S3 パス
+      s3_staging_dir: s3://health-logger-prod-env-data/athena-results/
+      region_name: ap-northeast-1
+      work_group: primary
+      # 認証方法:
+      #   aws_profile: ローカル開発向け（AWS CLI の設定を使う）
+      #   デフォルト（未指定）: 環境変数 AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+      # aws_profile: default
+
+    # =========================================================================
+    # DuckDB（ローカル完結・AWS 不要・開発・テスト向け）
+    # アダプター差し替え: DBT_ADAPTER=dbt-duckdb
+    # =========================================================================
+    # duckdb_local:
+    #   type: duckdb
+    #   path: /workspace/dev.duckdb   # コンテナ内のパス（ホスト側から見えるように volume 上に置く）
+    #   schema: main
+
+    # =========================================================================
+    # PostgreSQL（Docker Compose に postgres サービスを追加する場合）
+    # アダプター差し替え: DBT_ADAPTER=dbt-postgres
+    # =========================================================================
+    # postgres_local:
+    #   type: postgres
+    #   host: postgres          # docker-compose の service 名で解決できる
+    #   port: 5432
+    #   user: dbt
+    #   password: dbt
+    #   dbname: health_logger
+    #   schema: public
+    #   threads: 4
+
+    # =========================================================================
+    # BigQuery（GCP 環境向け）
+    # アダプター差し替え: DBT_ADAPTER=dbt-bigquery
+    # =========================================================================
+    # bigquery:
+    #   type: bigquery
+    #   method: oauth           # ローカル: oauth, CI: service-account
+    #   project: your-gcp-project-id
+    #   dataset: health_logger_dev
+    #   location: asia-northeast1
+    #   threads: 4

--- a/docker-compose.dbt.yml
+++ b/docker-compose.dbt.yml
@@ -1,0 +1,164 @@
+# =============================================================================
+# dbt + dbt-mcp sidecar 構成
+#
+# 使い方:
+#   推奨構成（dbt + dbt-mcp）:
+#     docker compose -f docker-compose.dbt.yml up -d
+#
+#   最小構成（dbt CLI のみ）:
+#     docker compose -f docker-compose.dbt.yml up -d dbt
+#
+#   dbt コマンド実行:
+#     docker compose -f docker-compose.dbt.yml exec dbt dbt run
+#     docker compose -f docker-compose.dbt.yml exec dbt dbt test
+#
+# 前提:
+#   - data/dbt/profiles/profiles.yml が存在すること（.gitignore済み）
+#   - data/dbt/.env が存在すること（.env.example からコピー）
+# =============================================================================
+
+services:
+
+  # ---------------------------------------------------------------------------
+  # dbt コンテナ
+  # 役割: dbt CLI の実行環境。sleep infinity で常駐し、
+  #       docker exec または docker compose exec で dbt コマンドを打つ。
+  # ---------------------------------------------------------------------------
+  dbt:
+    build:
+      context: .
+      dockerfile: docker/dbt/Dockerfile
+      args:
+        # アダプターを差し替えるだけで DWH を切り替えられる
+        # 例: dbt-postgres, dbt-bigquery, dbt-snowflake, dbt-athena-community
+        DBT_ADAPTER: ${DBT_ADAPTER:-dbt-athena-community}
+        DBT_ADAPTER_VERSION: ${DBT_ADAPTER_VERSION:-1.9.4}
+        DBT_CORE_VERSION: ${DBT_CORE_VERSION:-1.10.5}
+    container_name: health-logger-dbt
+    restart: "no"
+    # プロジェクトディレクトリを /workspace に統一
+    # → AIエージェント・devcontainer・CI すべてで同じパスで参照できる
+    volumes:
+      - ./data/dbt:/workspace                  # dbt プロジェクト全体
+      - ./data/dbt/profiles:/root/.dbt         # profiles.yml（認証情報）
+      - dbt-target:/workspace/target           # コンパイル成果物（dbt-mcp と共有）
+    working_dir: /workspace
+    environment:
+      DBT_PROJECT_DIR: /workspace
+      DBT_PROFILES_DIR: /root/.dbt
+      # AWS 認証は .env から注入（compose ファイルに直書きしない）
+      AWS_REGION: ${AWS_REGION:-ap-northeast-1}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
+    # sleep infinity で常駐。必要時に docker exec で dbt コマンドを実行する
+    command: sleep infinity
+    networks:
+      - dbt-net
+    # dbt debug でプロジェクト接続確認
+    healthcheck:
+      test: ["CMD", "dbt", "--version"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    env_file:
+      - path: ./data/dbt/.env
+        required: false   # .env がなくても起動できるようにする
+
+  # ---------------------------------------------------------------------------
+  # dbt-mcp コンテナ
+  # 役割: dbt MCP サーバー。Claude Code / Cursor / VS Code から HTTP で接続し、
+  #       dbt run / dbt test / dbt compile などを自然言語で実行できるようにする。
+  #
+  # 接続先: http://localhost:8811/mcp  (streamable-http)
+  #         http://localhost:8811/sse  (SSE の場合)
+  # ---------------------------------------------------------------------------
+  dbt-mcp:
+    build:
+      context: .
+      dockerfile: docker/dbt-mcp/Dockerfile
+      args:
+        DBT_ADAPTER: ${DBT_ADAPTER:-dbt-athena-community}
+        DBT_ADAPTER_VERSION: ${DBT_ADAPTER_VERSION:-1.9.4}
+        DBT_CORE_VERSION: ${DBT_CORE_VERSION:-1.10.5}
+        DBT_MCP_VERSION: ${DBT_MCP_VERSION:-1.10.0}
+    container_name: health-logger-dbt-mcp
+    restart: unless-stopped
+    volumes:
+      # dbt コンテナと完全に同じパスでマウント
+      # → manifest.json / catalog.json のパスがずれない
+      - ./data/dbt:/workspace
+      - ./data/dbt/profiles:/root/.dbt
+      - dbt-target:/workspace/target   # dbt コンテナが書いた成果物を読める
+    working_dir: /workspace
+    environment:
+      # --- dbt 設定 ---
+      DBT_PROJECT_DIR: /workspace
+      DBT_PROFILES_DIR: /root/.dbt
+      # dbt-mcp が内部で呼び出す dbt の実行パス
+      DBT_PATH: /usr/local/bin/dbt
+
+      # --- MCP トランスポート設定 ---
+      # streamable-http: MCP 最新仕様。Claude Code から接続する場合はこれ
+      # sse:             Server-Sent Events。古めのクライアント向け
+      # stdio:           ローカルプロセスとして Claude Desktop などが直接起動する場合
+      MCP_TRANSPORT: ${MCP_TRANSPORT:-streamable-http}
+      MCP_HOST: ${MCP_HOST:-0.0.0.0}   # コンテナ外から接続するため 0.0.0.0
+      MCP_PORT: ${MCP_PORT:-8811}
+
+      # --- dbt-mcp ツール有効化フラグ ---
+      # CLI ツール（dbt run / test / compile など）を有効化
+      DBT_MCP_ENABLE_DBT_CLI: "true"
+      # dbt Cloud の Semantic Layer / Admin API / Discovery API は今は不要
+      DBT_MCP_ENABLE_SEMANTIC_LAYER: ""
+      DBT_MCP_ENABLE_ADMIN_API: ""
+      DBT_MCP_ENABLE_DISCOVERY: ""
+
+      # AWS 認証（dbt-mcp が内部で dbt を呼ぶため必要）
+      AWS_REGION: ${AWS_REGION:-ap-northeast-1}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
+
+    # ホスト側のポートを公開。Claude Code の MCP 設定でこのポートに接続する
+    ports:
+      - "${MCP_PORT:-8811}:${MCP_PORT:-8811}"
+    depends_on:
+      dbt:
+        condition: service_healthy
+    networks:
+      - dbt-net
+    healthcheck:
+      # streamable-http の場合 /health エンドポイントがあれば使う
+      # なければ TCP ポートの疎通確認で代替
+      test: ["CMD", "python", "-c",
+             "import urllib.request; urllib.request.urlopen('http://localhost:${MCP_PORT:-8811}/health', timeout=5)"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 15s
+    env_file:
+      - path: ./data/dbt/.env
+        required: false
+
+# -----------------------------------------------------------------------------
+# ボリューム
+# dbt-target: dbt run / compile の成果物（manifest.json / catalog.json など）
+#             を dbt コンテナと dbt-mcp コンテナで共有するための named volume。
+#             ホストのファイルシステムには直接現れないが、
+#             docker compose exec dbt cat /workspace/target/manifest.json で確認可能。
+# -----------------------------------------------------------------------------
+volumes:
+  dbt-target:
+    name: health-logger-dbt-target
+
+# -----------------------------------------------------------------------------
+# ネットワーク
+# dbt-net: dbt と dbt-mcp が同一ネットワークに属することで、
+#          将来 dbt-mcp から dbt コンテナに直接リクエストを送る構成にも対応できる。
+# -----------------------------------------------------------------------------
+networks:
+  dbt-net:
+    name: health-logger-dbt-net
+    driver: bridge

--- a/docker/dbt-mcp/Dockerfile
+++ b/docker/dbt-mcp/Dockerfile
@@ -1,0 +1,105 @@
+# =============================================================================
+# dbt-mcp コンテナ
+#
+# 設計方針:
+# - dbt コンテナと同じベース・同じアダプターを使い、環境の一貫性を保つ
+# - dbt-mcp が内部で dbt CLI を呼び出すため、dbt も一緒にインストールする
+# - MCP_TRANSPORT=streamable-http でネイティブ HTTP 公開（supergateway 不要）
+# - uv を使って高速インストール（公式 Dockerfile に倣った構成）
+#
+# ⚠️ 不確実性の注記:
+# dbt-mcp の HTTP モードの起動オプション（--host / --port フラグ等）は
+# バージョンによって変わる可能性があります。
+# MCP_TRANSPORT / MCP_HOST / MCP_PORT が認識されない場合は、
+# entrypoint.sh で引数を直接渡すように変更してください。
+# 参照: https://github.com/dbt-labs/dbt-mcp
+# =============================================================================
+
+ARG PYTHON_VERSION=3.12
+ARG DBT_CORE_VERSION=1.10.5
+ARG DBT_ADAPTER=dbt-athena-community
+ARG DBT_ADAPTER_VERSION=1.9.4
+ARG DBT_MCP_VERSION=1.10.0
+
+# =============================================================================
+# Stage 1: uv を使った高速 builder
+# dbt Labs の公式 Dockerfile と同じアプローチを採用
+# =============================================================================
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+
+ARG DBT_CORE_VERSION
+ARG DBT_ADAPTER
+ARG DBT_ADAPTER_VERSION
+ARG DBT_MCP_VERSION
+
+# ビルド用システムパッケージ
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv で高速インストール（pip より大幅に速い）
+# --system: システムの Python にインストール
+# --no-cache: キャッシュなし（イメージサイズ削減）
+RUN uv pip install --system --no-cache \
+    "dbt-core==${DBT_CORE_VERSION}" \
+    "${DBT_ADAPTER}==${DBT_ADAPTER_VERSION}" \
+    "dbt-mcp==${DBT_MCP_VERSION}"
+
+# =============================================================================
+# Stage 2: runtime
+# =============================================================================
+FROM python:${PYTHON_VERSION}-slim-bookworm AS runtime
+
+LABEL org.opencontainers.image.title="health-logger-dbt-mcp"
+LABEL org.opencontainers.image.description="dbt-mcp MCP server for health-logger project"
+
+# ランタイム依存
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# builder からパッケージをコピー
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/bin/dbt /usr/local/bin/dbt
+COPY --from=builder /usr/local/bin/dbt-mcp /usr/local/bin/dbt-mcp
+
+WORKDIR /workspace
+
+RUN mkdir -p /root/.dbt
+
+ENV PATH="/usr/local/bin:${PATH}"
+ENV PYTHONUNBUFFERED=1
+
+# --- dbt 設定 ---
+ENV DBT_PROJECT_DIR=/workspace
+ENV DBT_PROFILES_DIR=/root/.dbt
+# dbt-mcp が内部で呼び出す dbt の絶対パス
+ENV DBT_PATH=/usr/local/bin/dbt
+
+# --- MCP トランスポート設定 ---
+# streamable-http: MCP 最新仕様。Claude Code の URL 接続に対応
+# sse:             旧来の SSE 形式。古いクライアント向け
+# stdio:           ローカルプロセスとして使う場合（HTTP 公開不要）
+ENV MCP_TRANSPORT=streamable-http
+ENV MCP_HOST=0.0.0.0
+ENV MCP_PORT=8811
+
+# --- dbt-mcp ツール有効化 ---
+ENV DBT_MCP_ENABLE_DBT_CLI=true
+ENV DBT_MCP_ENABLE_SEMANTIC_LAYER=""
+ENV DBT_MCP_ENABLE_ADMIN_API=""
+ENV DBT_MCP_ENABLE_DISCOVERY=""
+
+# 起動スクリプトをコピー（環境変数の検証 + dbt-mcp 起動）
+COPY docker/dbt-mcp/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# dbt と dbt-mcp のバージョン確認
+RUN dbt --version && dbt-mcp --help > /dev/null 2>&1 || echo "dbt-mcp installed"
+
+EXPOSE ${MCP_PORT}
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/dbt-mcp/entrypoint.sh
+++ b/docker/dbt-mcp/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# =============================================================================
+# dbt-mcp 起動スクリプト
+#
+# 役割:
+# 1. 必要な環境変数の検証
+# 2. dbt project の存在確認
+# 3. dbt-mcp を適切なトランスポートで起動
+#
+# ⚠️ dbt-mcp の HTTP 起動オプションはバージョンで変わる可能性があります。
+#    v1.10.0 時点では MCP_TRANSPORT 環境変数で制御できます。
+#    もし `dbt-mcp --transport` のような CLI フラグが必要になった場合は
+#    このスクリプトを修正してください。
+# =============================================================================
+
+set -e
+
+echo "[dbt-mcp] Starting..."
+echo "[dbt-mcp] Transport:    ${MCP_TRANSPORT}"
+echo "[dbt-mcp] Host:         ${MCP_HOST}"
+echo "[dbt-mcp] Port:         ${MCP_PORT}"
+echo "[dbt-mcp] Project dir:  ${DBT_PROJECT_DIR}"
+echo "[dbt-mcp] Profiles dir: ${DBT_PROFILES_DIR}"
+echo "[dbt-mcp] dbt path:     ${DBT_PATH}"
+
+# --- 必須ファイルの存在確認 ---
+if [ ! -f "${DBT_PROJECT_DIR}/dbt_project.yml" ]; then
+  echo "[dbt-mcp] ERROR: dbt_project.yml not found at ${DBT_PROJECT_DIR}"
+  echo "[dbt-mcp]        Volume マウントの設定を確認してください。"
+  exit 1
+fi
+
+if [ ! -f "${DBT_PROFILES_DIR}/profiles.yml" ]; then
+  echo "[dbt-mcp] WARNING: profiles.yml not found at ${DBT_PROFILES_DIR}"
+  echo "[dbt-mcp]          data/dbt/profiles/profiles.yml を作成してください。"
+  echo "[dbt-mcp]          data/dbt/profiles.yml.example を参考にしてください。"
+  echo "[dbt-mcp]          profiles.yml なしで起動を続けます（接続エラーになる可能性あり）。"
+fi
+
+# --- dbt パッケージのインストール確認 ---
+if [ ! -d "${DBT_PROJECT_DIR}/dbt_packages" ]; then
+  echo "[dbt-mcp] INFO: dbt_packages not found. Running dbt deps..."
+  cd "${DBT_PROJECT_DIR}" && dbt deps --profiles-dir "${DBT_PROFILES_DIR}" || \
+    echo "[dbt-mcp] WARNING: dbt deps failed. Continuing anyway."
+fi
+
+# --- dbt-mcp 起動 ---
+# MCP_TRANSPORT 環境変数は dbt-mcp が内部で参照する
+# streamable-http / sse / stdio のいずれかを指定
+echo "[dbt-mcp] Launching dbt-mcp server..."
+exec dbt-mcp

--- a/docker/dbt/Dockerfile
+++ b/docker/dbt/Dockerfile
@@ -1,0 +1,96 @@
+# =============================================================================
+# dbt CLI コンテナ
+#
+# 設計方針:
+# - python:3.12-slim をベースにして軽量に保つ
+# - DBT_ADAPTER を ARG で差し替え可能にして DWH 依存を排除する
+# - /workspace を dbt プロジェクトルートに統一（AIエージェント・devcontainer 対応）
+# - 非 root ユーザーで実行してセキュリティリスクを低減
+#
+# アダプター差し替え例（docker-compose.dbt.yml の DBT_ADAPTER を変更）:
+#   dbt-athena-community  ... Amazon Athena（デフォルト）
+#   dbt-postgres          ... PostgreSQL / Amazon RDS / Aurora
+#   dbt-bigquery          ... Google BigQuery
+#   dbt-snowflake         ... Snowflake
+#   dbt-redshift          ... Amazon Redshift
+#   dbt-duckdb            ... DuckDB（ローカル開発・テスト向け）
+# =============================================================================
+
+# --- ビルド引数 ---------------------------------------------------------------
+ARG PYTHON_VERSION=3.12
+ARG DBT_CORE_VERSION=1.10.5
+# アダプターのパッケージ名と、そのバージョン
+ARG DBT_ADAPTER=dbt-athena-community
+ARG DBT_ADAPTER_VERSION=1.9.4
+
+# =============================================================================
+# Stage 1: builder
+# pip install の成果物だけを次ステージにコピーして、イメージサイズを最小化する
+# =============================================================================
+FROM python:${PYTHON_VERSION}-slim AS builder
+
+ARG DBT_CORE_VERSION
+ARG DBT_ADAPTER
+ARG DBT_ADAPTER_VERSION
+
+# ビルドに必要な最小限のシステムパッケージのみインストール
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# pip の依存解決を高速化するため、wheel を先にインストール
+RUN pip install --upgrade pip wheel
+
+# site-packages を /install にインストール
+# → ランタイムステージにコピーするためのステージング領域
+RUN pip install --prefix=/install \
+    "dbt-core==${DBT_CORE_VERSION}" \
+    "${DBT_ADAPTER}==${DBT_ADAPTER_VERSION}"
+
+# =============================================================================
+# Stage 2: runtime
+# builder の成果物だけをコピーして、ビルドツールを含まない最小イメージを作る
+# =============================================================================
+FROM python:${PYTHON_VERSION}-slim AS runtime
+
+# ラベル（docker inspect や CI での識別に使う）
+LABEL org.opencontainers.image.title="health-logger-dbt"
+LABEL org.opencontainers.image.description="dbt CLI for health-logger project"
+
+# ランタイムに必要な最小限のパッケージ
+# git: dbt deps（パッケージのgitインストール）に必要
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# builder ステージの site-packages をコピー
+COPY --from=builder /install /usr/local
+
+# dbt プロジェクトルートを /workspace に統一
+# - AIエージェント（Claude Code / Cursor）からの参照パスが一定になる
+# - devcontainer.json の workspaceFolder とも合わせやすい
+WORKDIR /workspace
+
+# profiles ディレクトリを事前に作成（volumes マウント前に所有権を確保）
+RUN mkdir -p /root/.dbt
+
+# PATH に dbt が含まれることを確認
+ENV PATH="/usr/local/bin:${PATH}"
+
+# dbt のプロジェクト・profiles ディレクトリを環境変数でデフォルト設定
+# docker-compose.dbt.yml の environment セクションで上書き可能
+ENV DBT_PROJECT_DIR=/workspace
+ENV DBT_PROFILES_DIR=/root/.dbt
+
+# ログをバッファリングしない（docker logs でリアルタイムに表示される）
+ENV PYTHONUNBUFFERED=1
+
+# dbt のバージョンをビルド時に確認できるようにしておく
+RUN dbt --version
+
+# sleep infinity で常駐
+# → docker compose exec dbt dbt run のように外部からコマンドを注入して使う
+CMD ["sleep", "infinity"]

--- a/docs/dbt-docker-guide.md
+++ b/docs/dbt-docker-guide.md
@@ -1,0 +1,384 @@
+# dbt + dbt-mcp Docker Sidecar 構成ガイド
+
+## 1. 全体アーキテクチャ
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  ホスト（WSL2 / macOS / Linux）                              │
+│                                                             │
+│  Claude Code / Cursor / VS Code                             │
+│       │                                                     │
+│       │ HTTP (localhost:8811)                               │
+│       ▼                                                     │
+│  ┌─────────────────────────────────────────────┐           │
+│  │  Docker Compose ネットワーク (dbt-net)        │           │
+│  │                                             │           │
+│  │  ┌──────────────┐   ┌──────────────────┐   │           │
+│  │  │   dbt        │   │   dbt-mcp        │   │           │
+│  │  │  (CLI用)     │   │  (MCPサーバー)   │   │           │
+│  │  │              │   │                  │   │           │
+│  │  │ sleep ∞      │   │ MCP_TRANSPORT=   │   │           │
+│  │  │              │   │ streamable-http  │   │           │
+│  │  │ docker exec  │   │ :8811            │   │           │
+│  │  │ で dbt run   │   │                  │   │           │
+│  │  └──────┬───────┘   └────────┬─────────┘   │           │
+│  │         │                   │             │           │
+│  │         └─────────┬─────────┘             │           │
+│  │                   │ 共有ボリューム          │           │
+│  └───────────────────┼─────────────────────────┘           │
+│                      │                                     │
+│  ┌───────────────────▼───────────────────────┐             │
+│  │  ボリューム                                │             │
+│  │  ./data/dbt      → /workspace             │             │
+│  │  ./data/dbt/profiles → /root/.dbt         │             │
+│  │  dbt-target (named) → /workspace/target   │             │
+│  └────────────────────────────────────────────┘             │
+│                                                             │
+│                      │ Athena / DWH                        │
+│                      ▼                                     │
+│              AWS Athena（または他DWH）                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### この構成が嬉しい理由
+
+| 課題 | この構成での解決 |
+|---|---|
+| ホストに dbt をインストールしたくない | コンテナ内に閉じ込め、ホストは汚さない |
+| DWH を切り替えたい | `DBT_ADAPTER` 変数を変えてリビルドするだけ |
+| AI エージェントから dbt を操作したい | dbt-mcp が HTTP で常時待ち受け |
+| manifest.json を両コンテナで共有したい | named volume `dbt-target` で共有 |
+| 認証情報をコードに書きたくない | `.env` + `.gitignore` で管理 |
+| devcontainer 化したい | `/workspace` パスに統一済みで移行しやすい |
+
+---
+
+## 2. ディレクトリ構成
+
+```
+(project root)/
+├── docker-compose.dbt.yml          # sidecar compose 定義
+├── docker/
+│   ├── dbt/
+│   │   └── Dockerfile              # dbt CLI コンテナ（マルチステージ・軽量）
+│   └── dbt-mcp/
+│       ├── Dockerfile              # dbt-mcp コンテナ（uv ベース）
+│       └── entrypoint.sh           # 起動前検証 + dbt-mcp 起動
+└── data/dbt/
+    ├── .env.example                # 環境変数テンプレート（コミット済み）
+    ├── .env                        # 実際の環境変数（.gitignore済み）
+    ├── profiles/
+    │   ├── profiles.yml.example    # profiles テンプレート（コミット済み）
+    │   └── profiles.yml            # 実際の接続情報（.gitignore済み）
+    ├── dbt_project.yml
+    ├── models/
+    ├── macros/
+    ├── seeds/
+    ├── snapshots/
+    ├── tests/
+    ├── analyses/
+    └── docs/
+```
+
+---
+
+## 3. 初期セットアップ手順
+
+### Step 1: 環境変数ファイルの作成
+
+```bash
+cd /path/to/health-logger
+
+# .env を作成して編集
+cp data/dbt/.env.example data/dbt/.env
+# エディタで AWS 認証情報等を設定
+```
+
+### Step 2: profiles.yml の作成
+
+```bash
+cp data/dbt/profiles/profiles.yml.example data/dbt/profiles/profiles.yml
+# エディタで DWH 接続情報を設定
+```
+
+### Step 3: イメージのビルド
+
+```bash
+# 初回 or Dockerfile 変更時
+docker compose -f docker-compose.dbt.yml build
+
+# アダプターを変更する場合（例: BigQuery に切り替え）
+DBT_ADAPTER=dbt-bigquery DBT_ADAPTER_VERSION=1.9.0 \
+  docker compose -f docker-compose.dbt.yml build
+```
+
+### Step 4: 起動
+
+```bash
+# 推奨構成（dbt + dbt-mcp）
+docker compose -f docker-compose.dbt.yml up -d
+
+# 最小構成（dbt CLI のみ）
+docker compose -f docker-compose.dbt.yml up -d dbt
+```
+
+---
+
+## 4. 起動確認コマンド
+
+```bash
+# コンテナの状態確認
+docker compose -f docker-compose.dbt.yml ps
+
+# dbt バージョン確認
+docker compose -f docker-compose.dbt.yml exec dbt dbt --version
+
+# dbt 接続確認（profiles.yml が正しく設定されているか）
+docker compose -f docker-compose.dbt.yml exec dbt dbt debug
+
+# dbt パッケージインストール（dbt_utils など）
+docker compose -f docker-compose.dbt.yml exec dbt dbt deps
+
+# dbt-mcp ログ確認
+docker compose -f docker-compose.dbt.yml logs dbt-mcp
+
+# MCP サーバーの応答確認
+curl http://localhost:8811/health 2>/dev/null || \
+  echo "※ /health エンドポイントがない場合は /mcp にアクセスしてください"
+
+# よく使う dbt コマンド
+docker compose -f docker-compose.dbt.yml exec dbt dbt run
+docker compose -f docker-compose.dbt.yml exec dbt dbt test
+docker compose -f docker-compose.dbt.yml exec dbt dbt build
+docker compose -f docker-compose.dbt.yml exec dbt dbt source freshness
+docker compose -f docker-compose.dbt.yml exec dbt dbt docs generate
+
+# フルリビルド（incremental を最初から作り直す場合）
+docker compose -f docker-compose.dbt.yml exec dbt dbt run --full-refresh
+```
+
+---
+
+## 5. Claude Code への MCP 設定
+
+`dbt-mcp` コンテナが起動したら、Claude Code の MCP 設定に追加します。
+
+### `.mcp.json`（プロジェクトルートに配置）
+
+```json
+{
+  "mcpServers": {
+    "dbt": {
+      "type": "http",
+      "url": "http://localhost:8811/mcp"
+    }
+  }
+}
+```
+
+> **SSE の場合:** `"url": "http://localhost:8811/sse"` に変更
+
+設定後、Claude Code を再起動すると dbt ツールが使えるようになります。
+
+使用例:
+- 「`stg_env__hourly` を実行して」→ `dbt run --select stg_env__hourly`
+- 「全テストを実行して」→ `dbt test`
+- 「source の鮮度を確認して」→ `dbt source freshness`
+
+---
+
+## 6. 最小構成版 vs 推奨構成版
+
+### 最小構成版（dbt CLI のみ）
+
+```yaml
+# docker-compose.dbt.minimal.yml（参考）
+services:
+  dbt:
+    build:
+      context: .
+      dockerfile: docker/dbt/Dockerfile
+    volumes:
+      - ./data/dbt:/workspace
+      - ./data/dbt/profiles:/root/.dbt
+    command: sleep infinity
+    env_file:
+      - path: ./data/dbt/.env
+        required: false
+```
+
+**メリット:** シンプル・起動が速い
+**デメリット:** AI エージェントから操作できない
+
+### 推奨構成版（dbt + dbt-mcp sidecar）
+
+`docker-compose.dbt.yml` がそのまま推奨構成です。
+
+**メリット:** Claude Code / Cursor から自然言語で dbt を操作できる
+**デメリット:** コンテナが2つになる・ビルド時間が増える
+
+---
+
+## 7. DWH アダプターの差し替え方
+
+```bash
+# .env の DBT_ADAPTER を変更して再ビルド
+# 例: PostgreSQL に切り替える
+cat >> data/dbt/.env << 'EOF'
+DBT_ADAPTER=dbt-postgres
+DBT_ADAPTER_VERSION=1.9.0
+EOF
+
+docker compose -f docker-compose.dbt.yml build --no-cache
+docker compose -f docker-compose.dbt.yml up -d
+
+# profiles.yml の target も変更する（dbt-postgres 向けの接続情報に）
+```
+
+| アダプター | パッケージ名 | バージョン例 |
+|---|---|---|
+| Amazon Athena | `dbt-athena-community` | 1.9.4 |
+| PostgreSQL / Aurora | `dbt-postgres` | 1.9.0 |
+| Google BigQuery | `dbt-bigquery` | 1.9.0 |
+| Snowflake | `dbt-snowflake` | 1.9.0 |
+| Amazon Redshift | `dbt-redshift` | 1.9.0 |
+| DuckDB（ローカル完結） | `dbt-duckdb` | 1.9.0 |
+
+---
+
+## 8. トラブルシュート
+
+### profiles.yml が見つからない
+
+```
+RuntimeError: Could not find profile named 'health_logger'
+```
+
+→ `data/dbt/profiles/profiles.yml` が存在するか確認:
+
+```bash
+ls -la data/dbt/profiles/
+# profiles.yml がなければ
+cp data/dbt/profiles/profiles.yml.example data/dbt/profiles/profiles.yml
+```
+
+### AWS 認証エラー（Athena）
+
+```
+botocore.exceptions.NoCredentialsError: Unable to locate credentials
+```
+
+→ `data/dbt/.env` の AWS 設定を確認。または `~/.aws/credentials` をコンテナにマウント:
+
+```yaml
+# docker-compose.dbt.yml の dbt サービスに追加
+volumes:
+  - ~/.aws:/root/.aws:ro   # ホストの AWS 設定を読み取り専用でマウント
+```
+
+### dbt-mcp が起動しない
+
+```bash
+# ログを確認
+docker compose -f docker-compose.dbt.yml logs dbt-mcp
+
+# コンテナに入って手動で起動を試みる
+docker compose -f docker-compose.dbt.yml run --rm --entrypoint sh dbt-mcp
+# コンテナ内で:
+dbt-mcp --help
+MCP_TRANSPORT=streamable-http dbt-mcp
+```
+
+### MCP_PORT 8811 が既に使われている
+
+```bash
+# 使用ポートを変更（.env で指定）
+echo "MCP_PORT=8812" >> data/dbt/.env
+docker compose -f docker-compose.dbt.yml up -d
+```
+
+### dbt-target volume が古い
+
+```bash
+# named volume を削除して再作成
+docker compose -f docker-compose.dbt.yml down -v
+docker compose -f docker-compose.dbt.yml up -d
+```
+
+### Windows (WSL2) でのパス問題
+
+WSL2 ではホストの Windows パス（`C:\...`）を Docker にマウントできません。
+プロジェクトは必ず WSL2 のファイルシステム上（`/home/...` や `/mnt/...` ではない場所）に置いてください。
+
+---
+
+## 9. 将来拡張のポイント
+
+### devcontainer 化
+
+`/workspace` に統一しているため、以下を追加するだけで devcontainer として使えます:
+
+```json
+// .devcontainer/devcontainer.json
+{
+  "name": "health-logger dbt",
+  "dockerComposeFile": ["../docker-compose.dbt.yml"],
+  "service": "dbt",
+  "workspaceFolder": "/workspace",
+  "extensions": [
+    "innoverio.vscode-dbt-power-user",
+    "dbt-labs.dbt-power-user"
+  ]
+}
+```
+
+### CI/CD 組み込み
+
+```yaml
+# .github/workflows/dbt.yml
+jobs:
+  dbt:
+    steps:
+      - uses: actions/checkout@v4
+      - name: dbt build
+        run: |
+          cp data/dbt/profiles/profiles.yml.example data/dbt/profiles/profiles.yml
+          docker compose -f docker-compose.dbt.yml run --rm dbt \
+            sh -c "dbt deps && dbt build"
+        env:
+          AWS_REGION: ap-northeast-1
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+```
+
+### postgres サービスの追加（ローカル完結開発）
+
+```yaml
+# docker-compose.dbt.yml に追加
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: health_logger
+      POSTGRES_USER: dbt
+      POSTGRES_PASSWORD: dbt
+    networks:
+      - dbt-net
+```
+
+### dbt-mcp の stdio モードへの切り替え（Claude Desktop 用）
+
+```json
+// claude_desktop_config.json
+{
+  "mcpServers": {
+    "dbt": {
+      "command": "docker",
+      "args": [
+        "compose", "-f", "/path/to/docker-compose.dbt.yml",
+        "run", "--rm", "-e", "MCP_TRANSPORT=stdio", "dbt-mcp"
+      ]
+    }
+  }
+}
+```


### PR DESCRIPTION
## 関連イシュー
Closes #76

## 変更内容
- `docker-compose.dbt.yml`: dbt + dbt-mcp の sidecar 構成
- `docker/dbt/Dockerfile`: マルチステージ、`DBT_ADAPTER` ARG で DWH 差し替え可能
- `docker/dbt-mcp/Dockerfile`: uv ベース、streamable-http で HTTP 公開
- `docker/dbt-mcp/entrypoint.sh`: 起動前検証スクリプト
- `data/dbt/.env.example`: 環境変数テンプレート
- `data/dbt/profiles/profiles.yml.example`: Athena / PG / BQ / Snowflake 対応
- `.gitignore`: dbt 関連の機密ファイルを追加
- `docs/dbt-docker-guide.md`: セットアップ・確認・トラブルシュート・拡張方針

## テスト確認
- [x] npx tsc --noEmit → エラーなし（フロントエンド変更なし）
- [x] pytest lambda/ -v → 変更なし

## レビュー観点
- Dockerfile のマルチステージ構成・セキュリティ
- volume マウントのパス整合性（/workspace・/root/.dbt・dbt-target）
- entrypoint.sh の起動前検証ロジック