### PR TITLE
refactor: プロジェクト全体リファクタリング（Lambda テスト・ドキュメント整備・Rules 追加）

### DIFF
--- a/.claude/rules/dbt/modeling.md
+++ b/.claude/rules/dbt/modeling.md
@@ -1,0 +1,129 @@
+---
+paths:
+  - "data/dbt/**/*.sql"
+  - "data/dbt/**/*.yml"
+---
+# dbt モデリングルール
+
+## 命名規則
+
+| レイヤー | プレフィックス | 例 |
+|---------|-------------|-----|
+| staging | `stg_<source>__<entity>` | `stg_health__records` |
+| intermediate | `int_<domain>__<transform>` | `int_health__daily_scores` |
+| marts | `fct_<entity>` / `dim_<entity>` | `fct_health_env_joined_hourly` |
+
+ダブルアンダースコア `__` でソースとエンティティを区切る（プロジェクト規約）。
+
+## Materialization 戦略
+
+```yaml
+# dbt_project.yml に明示する
+models:
+  health_logger:
+    staging:
+      +materialized: view          # staging は view（軽量）
+    intermediate:
+      +materialized: table         # intermediate は table（再利用）
+    marts:
+      +materialized: incremental   # marts は incremental（差分更新）
+```
+
+incremental モデルの必須設定:
+
+```sql
+{{
+  config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partitioned_by=['dt'],
+    unique_key='id'
+  )
+}}
+
+{% if is_incremental() %}
+WHERE dt >= DATE_ADD('day', -3, current_date)
+{% endif %}
+```
+
+## スキーマテスト（`_*.yml`）
+
+新しいモデルには必ずスキーマファイルを作成する。
+
+```yaml
+models:
+  - name: stg_health__records
+    description: health_records の staging レイヤー
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique
+      - name: user_id
+        tests:
+          - not_null
+      - name: fatigue_score
+        tests:
+          - accepted_values:
+              values: [0, 1, 2, 3, 4, 5]
+```
+
+## Macro の使用
+
+プロジェクトのマクロを積極的に活用する:
+
+```sql
+-- FLAGS ビットマスクのデコード（macros/decode_flag.sql）
+{{ decode_flag('flags', 'poor_sleep', 1) }} AS flag_poor_sleep
+
+-- 気圧ラグフィーチャー（macros/pressure_lag_feature.sql）
+{{ pressure_lag_feature('surface_pressure', hours=3) }} AS pressure_diff_3h
+
+-- NULL 安全キャスト（macros/safe_cast.sql）
+{{ safe_cast('raw_value', 'INTEGER') }} AS int_value
+```
+
+## Athena (S3 Tables) 対応
+
+- `dbt-athena-community` アダプターを使用
+- `s3_staging_dir` は必ず設定する（`profiles.yml`）
+- パーティションカラムは `dt DATE` を使用
+- `MSCK REPAIR TABLE` は不要（S3 Tables は自動パーティション）
+- スキーマ変更後は Athena で `ALTER TABLE ... ADD COLUMNS (...)` を実行
+
+## Sources の鮮度確認
+
+```yaml
+sources:
+  - name: health_logs
+    freshness:
+      warn_after: {count: 24, period: hour}
+      error_after: {count: 48, period: hour}
+    loaded_at_field: recorded_at
+```
+
+```bash
+# 鮮度チェック
+dbt source freshness
+```
+
+## テスト実行
+
+```bash
+# ビルド（compile + run + test）
+dbt build
+
+# テストのみ
+dbt test --select staging
+
+# 特定モデルのみ
+dbt run --select +fct_health_env_joined_hourly
+dbt test --select +fct_health_env_joined_hourly
+```
+
+## インクリメンタルのフルリフレッシュ
+
+```bash
+# 過去データを含めて全件再計算（月次など）
+dbt run --full-refresh --select fct_health_env_joined_hourly
+```

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,512 @@
+# API リファレンス
+
+> 対象読者: 開発者
+> health-logger の全 API エンドポイント仕様をまとめる。
+
+---
+
+## 共通仕様
+
+### ベース URL
+
+```
+https://<api-id>.execute-api.ap-northeast-1.amazonaws.com
+```
+
+実際のエンドポイント URL は Terraform の出力値 `api_endpoint` を参照すること。
+
+### 認証
+
+全エンドポイント（`/health` を除く）に Cognito JWT が必要。
+
+```
+Authorization: Bearer <Cognito ID Token>
+```
+
+JWT トークンは `fetchAuthSession()` で取得する:
+
+```typescript
+import { fetchAuthSession } from 'aws-amplify/auth'
+
+const session = await fetchAuthSession()
+const token = session.tokens?.idToken?.toString()
+```
+
+トークンの有効期限は 1 時間。Amplify ライブラリが自動でリフレッシュする。
+
+### レスポンス形式
+
+```json
+Content-Type: application/json
+```
+
+### 共通エラーコード
+
+| HTTP Status | 意味 |
+|------------|------|
+| 400 | リクエストの形式・値が不正 |
+| 401 | 認証トークンがない・無効 |
+| 504 | Athena クエリがタイムアウト（10秒以内に完了しなかった） |
+| 500 | サーバー内部エラー |
+
+---
+
+## エンドポイント一覧
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| POST | /records | 体調記録を作成 |
+| GET | /records/latest | 体調記録を取得 |
+| DELETE | /records/{id} | 体調記録を削除 |
+| GET | /item-config | カスタム項目設定を取得 |
+| PUT | /item-config | カスタム項目設定を保存 |
+| POST | /push/subscribe | プッシュ通知を購読 |
+| DELETE | /push/subscribe | プッシュ通知を解除 |
+| GET | /env | 環境データを取得（内部 Lambda 向け） |
+
+---
+
+## POST /records
+
+体調記録を 1 件作成する。Lambda が Kinesis Firehose 経由で S3 (Iceberg) に書き込む。
+
+### リクエスト
+
+```
+POST /records
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+**ボディ（JSON）**
+
+| フィールド | 型 | 必須 | 制約 | 説明 |
+|-----------|-----|------|------|------|
+| `record_type` | string | 任意 | `"daily"` / `"event"` / `"status"` | 記録種別（デフォルト: `"daily"`） |
+| `fatigue_score` | integer | 任意 | 0 〜 100 | 疲労感スコア |
+| `mood_score` | integer | 任意 | 0 〜 100 | 気分スコア |
+| `motivation_score` | integer | 任意 | 0 〜 100 | やる気スコア |
+| `flags` | integer | 任意 | 0 〜 63 | ビットマスク（詳細は DATABASE_SCHEMA.md 参照） |
+| `note` | string | 任意 | 280文字以内 | メモ（デフォルト: 空文字） |
+| `recorded_at` | string | **必須** | ISO 8601 形式 | 記録日時（例: `"2026-03-16T08:00:00+09:00"`） |
+| `timezone` | string | 任意 | TZ 名 | タイムゾーン（デフォルト: `"UTC"`） |
+| `device_id` | string | 任意 | — | デバイス識別子 |
+| `app_version` | string | 任意 | — | アプリバージョン（デフォルト: `"1.0.0"`） |
+| `custom_fields` | array | 任意 | — | カスタム項目の値配列（下記参照） |
+
+**`custom_fields` の要素**
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `item_id` | string | 必須 | カスタム項目 ID |
+| `label` | string | 必須 | 表示ラベル |
+| `type` | string | 必須 | `"slider"` / `"checkbox"` / `"number"` / `"text"` |
+| `value` | number \| boolean \| string | 必須 | 記録値 |
+
+**リクエスト例**
+
+```json
+{
+  "record_type": "daily",
+  "fatigue_score": 60,
+  "mood_score": 70,
+  "motivation_score": 50,
+  "flags": 9,
+  "note": "今日は少し疲れた",
+  "recorded_at": "2026-03-16T08:00:00+09:00",
+  "timezone": "Asia/Tokyo",
+  "device_id": "browser-abc123",
+  "app_version": "1.2.0",
+  "custom_fields": [
+    {
+      "item_id": "custom_001",
+      "label": "睡眠時間",
+      "type": "number",
+      "value": 7.5
+    }
+  ]
+}
+```
+
+### レスポンス
+
+**成功（201）**
+
+```json
+{
+  "record_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**バリデーションエラー（400）**
+
+```json
+{
+  "error": "Validation failed",
+  "details": [
+    {
+      "loc": ["fatigue_score"],
+      "msg": "Input should be less than or equal to 100",
+      "type": "less_than_equal"
+    }
+  ]
+}
+```
+
+**認証エラー（401）**
+
+```json
+{
+  "error": "Unauthorized"
+}
+```
+
+---
+
+## GET /records/latest
+
+直近の体調記録を取得する。Athena にクエリを発行し、最大 10 秒ポーリングして結果を返す。
+
+### リクエスト
+
+```
+GET /records/latest?limit=10
+Authorization: Bearer <token>
+```
+
+**クエリパラメータ**
+
+| パラメータ | 型 | 必須 | 制約 | 説明 |
+|-----------|-----|------|------|------|
+| `limit` | integer | 任意 | 1 〜 100（デフォルト: 10） | 取得件数 |
+
+### レスポンス
+
+**成功（200）**
+
+```json
+{
+  "records": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "record_type": "daily",
+      "fatigue_score": "60",
+      "mood_score": "70",
+      "motivation_score": "50",
+      "flags": "9",
+      "note": "今日は少し疲れた",
+      "recorded_at": "2026-03-16 08:00:00.000",
+      "timezone": "Asia/Tokyo",
+      "device_id": "browser-abc123",
+      "app_version": "1.2.0",
+      "custom_fields": "[{\"item_id\":\"custom_001\",\"label\":\"睡眠時間\",\"type\":\"number\",\"value\":7.5}]",
+      "written_at": "2026-03-16 08:00:05.123"
+    }
+  ]
+}
+```
+
+> 注意: Athena はすべての値を文字列として返す。フロントエンド側で数値に変換すること。
+> `custom_fields` は JSON 文字列であるため `JSON.parse()` が必要。
+
+**クエリタイムアウト（504）**
+
+```json
+{
+  "error": "Query timeout"
+}
+```
+
+---
+
+## DELETE /records/{id}
+
+指定した体調記録を削除する。`user_id` で所有者チェックを行い、他ユーザーのレコードは削除できない。
+
+### リクエスト
+
+```
+DELETE /records/{id}
+Authorization: Bearer <token>
+```
+
+**パスパラメータ**
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `id` | string (UUID) | 必須 | 削除するレコードの ID |
+
+### レスポンス
+
+**成功（200）**
+
+```json
+{
+  "message": "deleted"
+}
+```
+
+**不正な ID 形式（400）**
+
+```json
+{
+  "error": "Invalid record ID"
+}
+```
+
+**削除失敗（500）**
+
+```json
+{
+  "error": "Delete failed",
+  "reason": "..."
+}
+```
+
+---
+
+## GET /item-config
+
+ユーザーのカスタム項目設定を取得する。DynamoDB から取得する。
+
+### リクエスト
+
+```
+GET /item-config
+Authorization: Bearer <token>
+```
+
+### レスポンス
+
+**成功（200）**
+
+```json
+{
+  "configs": [
+    {
+      "item_id": "custom_001",
+      "label": "睡眠時間",
+      "type": "number",
+      "mode": "form",
+      "order": 1,
+      "unit": "時間",
+      "min": 0,
+      "max": 24
+    },
+    {
+      "item_id": "custom_002",
+      "label": "頭痛の強さ",
+      "type": "slider",
+      "mode": "status",
+      "order": 2,
+      "min": 0,
+      "max": 10
+    }
+  ]
+}
+```
+
+設定が未登録の場合は空配列 `{ "configs": [] }` を返す。
+
+---
+
+## PUT /item-config
+
+ユーザーのカスタム項目設定を保存する。既存の設定は全件上書きされる。
+
+### リクエスト
+
+```
+PUT /item-config
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+**ボディ（JSON）**
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `configs` | array | 必須 | 項目設定の配列 |
+
+**`configs` の各要素**
+
+| フィールド | 型 | 必須 | 制約 | 説明 |
+|-----------|-----|------|------|------|
+| `item_id` | string | 必須 | — | 一意の識別子 |
+| `label` | string | 必須 | — | 表示ラベル |
+| `type` | string | 必須 | `"slider"` / `"checkbox"` / `"number"` / `"text"` | 入力種別 |
+| `mode` | string | 必須 | `"form"` / `"event"` / `"status"` | 表示モード |
+| `order` | number | 任意 | — | 表示順序 |
+| `icon` | string | 任意 | — | アイコン名 |
+| `min` | number | 任意 | — | 最小値（slider / number） |
+| `max` | number | 任意 | — | 最大値（slider / number） |
+| `unit` | string | 任意 | — | 単位（例: `"時間"`, `"kg"`） |
+
+**リクエスト例**
+
+```json
+{
+  "configs": [
+    {
+      "item_id": "custom_001",
+      "label": "睡眠時間",
+      "type": "number",
+      "mode": "form",
+      "order": 1,
+      "unit": "時間",
+      "min": 0,
+      "max": 24
+    }
+  ]
+}
+```
+
+### レスポンス
+
+**成功（200）**
+
+```json
+{
+  "message": "saved"
+}
+```
+
+**バリデーションエラー（400）**
+
+```json
+{
+  "error": "type must be one of ['checkbox', 'number', 'slider', 'text']"
+}
+```
+
+---
+
+## POST /push/subscribe
+
+Web Push 通知の購読を登録する。ブラウザの `PushSubscription` オブジェクトを送信する。
+
+### リクエスト
+
+```
+POST /push/subscribe
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+**ボディ（JSON）**
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `subscription` | object | 必須 | Web Push Subscription オブジェクト |
+| `subscription.endpoint` | string | 必須 | ブラウザの Push エンドポイント URL |
+| `subscription.keys` | object | 必須 | `p256dh` / `auth` キーを含むオブジェクト |
+
+**リクエスト例**
+
+```json
+{
+  "subscription": {
+    "endpoint": "https://fcm.googleapis.com/fcm/send/...",
+    "keys": {
+      "p256dh": "BXXXXXXXXXXXXXXXXXXXXXXX...",
+      "auth": "AXXXXXXXXXX..."
+    }
+  }
+}
+```
+
+### レスポンス
+
+**成功（200）**
+
+```json
+{
+  "message": "subscribed"
+}
+```
+
+---
+
+## DELETE /push/subscribe
+
+Web Push 通知の購読を解除する。DynamoDB から購読情報を削除する。
+
+### リクエスト
+
+```
+DELETE /push/subscribe
+Authorization: Bearer <token>
+```
+
+### レスポンス
+
+**成功（200）**
+
+```json
+{
+  "message": "unsubscribed"
+}
+```
+
+---
+
+## GET /env（内部 Lambda 向け）
+
+環境データ（気象・大気質）を Open-Meteo API から取得して S3 に保存する。
+API Gateway 経由のエンドポイントではなく、EventBridge スケジューラーから呼び出す内部 Lambda。
+
+### 呼び出し方法
+
+EventBridge から自動実行（デフォルト: 毎日前日分を取得）。
+
+手動実行する場合は AWS CLI で Lambda を直接呼び出す:
+
+```bash
+aws lambda invoke \
+  --function-name health-logger-prod-get-env-data \
+  --payload '{}' \
+  --region ap-northeast-1 \
+  output.json
+```
+
+バックフィル（過去日分の一括取得）:
+
+```bash
+aws lambda invoke \
+  --function-name health-logger-prod-get-env-data \
+  --payload '{"backfill": true, "date_from": "2026-01-01", "date_to": "2026-01-31"}' \
+  --region ap-northeast-1 \
+  output.json
+```
+
+### ペイロード（オプション）
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `backfill` | boolean | 任意 | `true` にすると `date_from` 〜 `date_to` の範囲を取得 |
+| `date_from` | string | backfill 時 | 開始日（`YYYY-MM-DD`） |
+| `date_to` | string | backfill 時 | 終了日（`YYYY-MM-DD`） |
+| `location_id` | string | 任意 | 地点 ID（デフォルト: `"musashikosugi"`） |
+
+### レスポンス
+
+**成功（200）**
+
+```json
+{
+  "message": "Success",
+  "total_records": 24,
+  "saved_files": 1
+}
+```
+
+---
+
+## ヘルスチェック
+
+`GET /records/latest` を処理する Lambda は `/health` パスに対して認証なしで 200 を返す。
+
+```bash
+curl https://<api-endpoint>/health
+# → {"status": "ok"}
+```

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -1,0 +1,220 @@
+# データベーススキーマ
+
+> 対象読者: 開発者
+> S3 Tables (Iceberg) および DynamoDB のテーブル構成を記載する。
+
+---
+
+## 1. S3 Tables (Iceberg) — health_records
+
+体調記録の主テーブル。Kinesis Firehose が Iceberg 形式で S3 Tables に書き込む。
+Athena からクエリする場合は Glue カタログを経由する。
+
+### カラム定義
+
+| カラム名 | 型 | 必須 | 説明 |
+|---------|-----|------|------|
+| `id` | string (UUID) | 必須 | レコード一意識別子（`uuid.uuid4()` で生成） |
+| `user_id` | string (UUID) | 必須 | Cognito の `sub`（ユーザー識別子） |
+| `record_type` | string | 必須 | 記録種別: `"daily"` / `"event"` / `"status"` |
+| `fatigue_score` | integer | 任意 | 疲労感（0 〜 100）。NULL 許容 |
+| `mood_score` | integer | 任意 | 気分（0 〜 100）。NULL 許容 |
+| `motivation_score` | integer | 任意 | やる気（0 〜 100）。NULL 許容 |
+| `flags` | integer | 必須 | ビットマスク（下記参照） |
+| `note` | string | 任意 | メモ（280文字以内）。デフォルト空文字 |
+| `recorded_at` | string (ISO 8601) | 必須 | ユーザーが記録した日時 |
+| `timezone` | string | 任意 | タイムゾーン名（例: `"Asia/Tokyo"`） |
+| `device_id` | string | 任意 | デバイス識別子 |
+| `app_version` | string | 任意 | アプリバージョン（例: `"1.2.0"`） |
+| `custom_fields` | string (JSON) | 任意 | カスタム項目の値配列（下記参照） |
+| `written_at` | string (ISO 8601) | 必須 | Lambda が書き込んだ UTC 日時 |
+| `dt` | string (YYYY-MM-DD) | 必須 | パーティション列（`recorded_at` の日付部分） |
+
+### パーティション戦略
+
+```
+パーティション列: dt = YYYY-MM-DD
+```
+
+`recorded_at` の先頭 10 文字（`YYYY-MM-DD`）を `dt` として保存する。
+Athena クエリで `WHERE dt = '2026-03-16'` のように絞り込むとパーティションプルーニングが働き、
+スキャン量を大幅に削減できる。
+
+```sql
+-- パーティションを活用したクエリ例
+SELECT * FROM health_records
+WHERE user_id = '...'
+  AND dt BETWEEN '2026-03-01' AND '2026-03-16'
+ORDER BY recorded_at DESC
+LIMIT 10
+```
+
+---
+
+## 2. FLAGS ビットマスク
+
+`flags` カラムはビットマスク（整数）でライフスタイルフラグを記録する。
+
+| フラグ名 | ビット値 | 説明 |
+|---------|---------|------|
+| `poor_sleep` | 1 (2^0) | 睡眠の質が悪かった |
+| `headache` | 2 (2^1) | 頭痛あり |
+| `stomachache` | 4 (2^2) | 腹痛あり |
+| `exercise` | 8 (2^3) | 運動した |
+| `alcohol` | 16 (2^4) | 飲酒した |
+| `caffeine` | 32 (2^5) | カフェインを摂取した |
+
+**最大値**: 63（すべてのフラグが ON の場合: 1+2+4+8+16+32）
+
+**計算例**
+
+```python
+# 睡眠不足 + 運動 のフラグを設定する場合
+flags = 1 + 8  # = 9
+
+# フラグの読み出し
+has_poor_sleep  = (flags & 1) != 0   # True
+has_headache    = (flags & 2) != 0   # False
+has_stomachache = (flags & 4) != 0   # False
+did_exercise    = (flags & 8) != 0   # True
+had_alcohol     = (flags & 16) != 0  # False
+had_caffeine    = (flags & 32) != 0  # False
+```
+
+**dbt でのデコード例（Athena SQL）**
+
+```sql
+-- fct_health_env_joined_hourly.sql より
+bitwise_and(flags, 1)  != 0 as has_poor_sleep,
+bitwise_and(flags, 2)  != 0 as has_headache,
+bitwise_and(flags, 4)  != 0 as has_stomachache,
+bitwise_and(flags, 8)  != 0 as did_exercise,
+bitwise_and(flags, 16) != 0 as had_alcohol,
+bitwise_and(flags, 32) != 0 as had_caffeine
+```
+
+---
+
+## 3. custom_fields の JSON 構造
+
+`custom_fields` カラムは JSON 文字列として保存される（Athena の Iceberg 制約のため）。
+
+**フォーマット**
+
+```json
+[
+  {
+    "item_id": "custom_001",
+    "label": "睡眠時間",
+    "type": "number",
+    "value": 7.5
+  },
+  {
+    "item_id": "custom_002",
+    "label": "頭痛の強さ",
+    "type": "slider",
+    "value": 3
+  },
+  {
+    "item_id": "custom_003",
+    "label": "ストレッチした",
+    "type": "checkbox",
+    "value": true
+  }
+]
+```
+
+**`type` の種別と `value` の型対応**
+
+| type | value の型 | 説明 |
+|------|-----------|------|
+| `slider` | integer / float | スライダー値 |
+| `checkbox` | boolean | チェックボックス |
+| `number` | integer / float | 数値入力 |
+| `text` | string | テキスト入力 |
+
+**Athena での読み出し例**
+
+```sql
+-- custom_fields は文字列なので JSON 関数で展開
+SELECT
+  id,
+  recorded_at,
+  json_extract_scalar(cf, '$.value') AS custom_value,
+  json_extract_scalar(cf, '$.label') AS custom_label
+FROM health_records
+CROSS JOIN UNNEST(CAST(json_parse(custom_fields) AS ARRAY(JSON))) AS t(cf)
+WHERE user_id = '...'
+  AND json_extract_scalar(cf, '$.item_id') = 'custom_001'
+```
+
+---
+
+## 4. Iceberg スキーマ変更の注意事項
+
+Terraform の `glue:UpdateTable` は **Glue カタログのメタデータのみ**を更新する。
+S3 上の Iceberg メタデータファイル（`metadata.json`）は自動では更新されない。
+
+### カラム追加後に必要な手順
+
+`terraform apply` でカラムを追加した後、Athena DDL を手動実行すること:
+
+```bash
+aws athena start-query-execution \
+  --query-string "ALTER TABLE health_records ADD COLUMNS (new_col string)" \
+  --query-execution-context Database=health_logger_prod_health_logs \
+  --result-configuration OutputLocation=s3://health-logger-prod/athena-results/ \
+  --region ap-northeast-1
+```
+
+この手順を省略すると `get_latest` Lambda が `COLUMN_NOT_FOUND` エラーで全件 500 になる。
+
+**過去の失敗**: PR #16 で `record_type`/`custom_fields` を追加した際に ALTER TABLE を省略してしまい、
+本番で全リクエストが 500 エラーになった。Glue カラム追加後は必ず Athena DDL を実行すること。
+
+---
+
+## 5. DynamoDB — item_configs
+
+ユーザーのカスタム項目設定を保存するテーブル。
+
+**テーブル名**: `health-logger-prod-item-configs`
+
+| 属性 | 型 | キー種別 | 説明 |
+|------|-----|---------|------|
+| `user_id` | String | パーティションキー | Cognito の `sub` |
+| `configs` | String | — | `ItemConfig[]` を JSON 文字列化した値 |
+
+**特徴**:
+- ユーザーごとに 1 レコード（全設定を 1 アイテムにまとめて保存）
+- 設定の保存は `PutItem`（全件上書き）、取得は `GetItem`
+- TTL / GSI は設定なし
+
+---
+
+## 6. DynamoDB — push_subscriptions
+
+Web Push 通知の購読情報を保存するテーブル。
+
+**テーブル名**: `health-logger-prod-push-subscriptions`
+
+| 属性 | 型 | キー種別 | 説明 |
+|------|-----|---------|------|
+| `user_id` | String | パーティションキー | Cognito の `sub` |
+| `subscription` | String | — | Web Push `PushSubscription` を JSON 文字列化した値 |
+
+**`subscription` の内部構造**
+
+```json
+{
+  "endpoint": "https://fcm.googleapis.com/fcm/send/...",
+  "keys": {
+    "p256dh": "BXXXXXXXXXXXXXXXXXXXXXXX...",
+    "auth": "AXXXXXXXXXX..."
+  }
+}
+```
+
+**購読の自動削除**:
+`push_notify` Lambda がプッシュ送信に失敗し、ブラウザから 404 または 410 が返った場合、
+その購読情報を自動的に DynamoDB から削除する（期限切れ・手動解除済みの端末をクリーンアップ）。

--- a/docs/DBT_OPERATIONS.md
+++ b/docs/DBT_OPERATIONS.md
@@ -1,0 +1,252 @@
+# dbt 操作ガイド
+
+> 対象読者: 開発者・データエンジニア
+> dbt の実行方法・モデル構成・運用上の注意点を記載する。
+
+---
+
+## 概要
+
+dbt は環境データ（気象・花粉・大気質）の変換レイヤーとして使用する。
+Athena（dbt-athena-community アダプター）を DWH として使用する。
+
+**CI/CD には組み込まれていない。** ローカルまたは devcontainer から手動実行する。
+
+### dbt モデルの構成
+
+```
+data/dbt/models/
+  staging/
+    stg_env__hourly.sql         # 環境データ（型変換・クレンジング）
+    stg_health__records.sql     # 体調記録（型変換・正規化）
+  intermediate/
+    int_env_daily_agg.sql       # 環境データ日次集約
+    int_env_pressure_features.sql  # 気圧フィーチャー計算
+    int_health__daily_scores.sql   # 体調スコア日次集約
+  marts/
+    environment/
+      fct_environment_hourly.sql  # 環境データ（時間粒度、公開用）
+      fct_environment_daily.sql   # 環境データ（日次粒度、公開用）
+    health/
+      fct_health_env_joined_hourly.sql  # 体調 × 環境 結合ファクト
+```
+
+**データリネージ**:
+
+```
+raw_env (S3 / Glue)        health_records (Iceberg)
+        ↓                          ↓
+  stg_env__hourly          stg_health__records
+        ↓                          ↓
+  int_env_daily_agg         int_health__daily_scores
+  int_env_pressure_features
+        ↓                          ↓
+  fct_environment_hourly ──→ fct_health_env_joined_hourly
+  fct_environment_daily
+```
+
+---
+
+## 実行方法
+
+### 方法 1: Docker Compose（推奨）
+
+dbt と dbt-mcp（AI コーディング用 MCP サーバー）を含む構成。
+
+**起動**:
+
+```bash
+# 全サービス起動（dbt + dbt-mcp）
+docker compose -f docker-compose.dbt.yml up -d
+
+# dbt のみ起動（最小構成）
+docker compose -f docker-compose.dbt.yml up -d dbt
+```
+
+**前提条件**:
+- `data/dbt/profiles/profiles.yml` が存在すること（後述）
+- `~/.aws` に認証情報が設定されていること
+
+**dbt コマンドの実行**:
+
+```bash
+# dbt run（全モデルを実行）
+docker compose -f docker-compose.dbt.yml exec dbt dbt run
+
+# dbt test（全テストを実行）
+docker compose -f docker-compose.dbt.yml exec dbt dbt test
+
+# 特定のモデルのみ実行
+docker compose -f docker-compose.dbt.yml exec dbt dbt run --select stg_env__hourly
+
+# ドキュメント生成
+docker compose -f docker-compose.dbt.yml exec dbt dbt docs generate
+```
+
+### 方法 2: devcontainer（VS Code）
+
+`.devcontainer/` の構成で VS Code Dev Container を使用する場合、
+コンテナ内で直接 dbt コマンドを実行できる。
+
+```bash
+# コンテナ内のターミナルで実行
+cd /workspace
+dbt run
+dbt test
+```
+
+---
+
+## profiles.yml の設定
+
+`data/dbt/profiles/profiles.yml` はリポジトリ管理外（`.gitignore` 済み）。
+初回セットアップ時に手動で作成する。
+
+```yaml
+health_logger_dbt:
+  target: prod
+  outputs:
+    prod:
+      type: athena
+      region_name: ap-northeast-1
+      s3_staging_dir: s3://health-logger-prod/dbt-staging/
+      schema: health_logger_dbt_prod
+      database: awsdatacatalog
+      aws_profile: default  # ~/.aws/credentials のプロファイル名
+      work_group: primary
+```
+
+> `s3_staging_dir` は Athena のクエリ結果保存先。prod バケット内の専用プレフィックスを使う。
+
+---
+
+## 主要コマンドリファレンス
+
+### dbt build（run + test を一括実行）
+
+```bash
+docker compose -f docker-compose.dbt.yml exec dbt dbt build
+```
+
+### dbt run（モデルの実行）
+
+```bash
+# 全モデルを実行
+docker compose -f docker-compose.dbt.yml exec dbt dbt run
+
+# 特定のモデルのみ
+docker compose -f docker-compose.dbt.yml exec dbt dbt run --select fct_health_env_joined_hourly
+
+# 依存するモデルも含めて実行（+ を付ける）
+docker compose -f docker-compose.dbt.yml exec dbt dbt run --select +fct_health_env_joined_hourly
+
+# 特定のタグのモデルのみ
+docker compose -f docker-compose.dbt.yml exec dbt dbt run --select tag:daily
+```
+
+### dbt test
+
+```bash
+# 全テストを実行
+docker compose -f docker-compose.dbt.yml exec dbt dbt test
+
+# 特定のモデルのテストのみ
+docker compose -f docker-compose.dbt.yml exec dbt dbt test --select stg_env__hourly
+```
+
+### インクリメンタルモデルのフルリフレッシュ
+
+インクリメンタルモデルで過去データを再計算したい場合:
+
+```bash
+docker compose -f docker-compose.dbt.yml exec dbt dbt run --full-refresh
+```
+
+フルリフレッシュは既存テーブルを DROP して再作成するため、実行前に影響範囲を確認すること。
+
+### source freshness チェック
+
+ソースデータが期待通りの鮮度で届いているか確認する:
+
+```bash
+docker compose -f docker-compose.dbt.yml exec dbt dbt source freshness
+```
+
+`sources.yml` に `freshness` 設定がある場合、閾値超えで警告またはエラーになる。
+
+### dbt docs の生成と確認
+
+```bash
+# ドキュメント生成
+docker compose -f docker-compose.dbt.yml exec dbt dbt docs generate
+
+# ドキュメントサーバーの起動
+docker compose -f docker-compose.dbt.yml exec dbt dbt docs serve --port 8080
+```
+
+ブラウザで `http://localhost:8080` にアクセスすると、モデルのリネージグラフや
+カラム定義を視覚的に確認できる。
+
+---
+
+## dbt-mcp サーバー（AI コーディング連携）
+
+dbt-mcp コンテナは Claude Code などの AI ツールから dbt 操作を自然言語で実行できる MCP サーバー。
+
+**接続先**: `http://localhost:8811/mcp`
+
+Claude Code の MCP 設定（`.claude/mcp_settings.json`）に追加することで使用できる。
+
+起動確認:
+
+```bash
+curl http://localhost:8811/mcp
+```
+
+---
+
+## スキーマ変更時の注意
+
+dbt モデルのカラムを変更（追加・削除・型変更）する場合:
+
+### 1. Athena（Iceberg）テーブルへの影響確認
+
+`stg_health__records.sql` は `health_records` Iceberg テーブルを参照している。
+`health_records` にカラムを追加した後は、Athena で ALTER TABLE が必要:
+
+```bash
+aws athena start-query-execution \
+  --query-string "ALTER TABLE health_records ADD COLUMNS (new_col string)" \
+  --query-execution-context Database=health_logger_prod_health_logs \
+  --result-configuration OutputLocation=s3://health-logger-prod/athena-results/ \
+  --region ap-northeast-1
+```
+
+### 2. dbt モデルの更新
+
+1. 対象の `.sql` ファイルを修正する
+2. 対応する `schema.yml` のカラム定義も更新する
+3. `dbt run --select <変更したモデル> --full-refresh` で再実行する
+
+### 3. 下流モデルへの影響確認
+
+```bash
+# 変更したモデルの下流モデルをすべて確認
+docker compose -f docker-compose.dbt.yml exec dbt dbt ls --select stg_env__hourly+
+```
+
+`+` を末尾に付けると下流モデル（依存しているモデル）の一覧が表示される。
+
+---
+
+## コンテナの停止
+
+```bash
+docker compose -f docker-compose.dbt.yml down
+```
+
+dbt-target ボリューム（コンパイル成果物）も削除する場合:
+
+```bash
+docker compose -f docker-compose.dbt.yml down -v
+```

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,265 @@
+# デプロイガイド
+
+> 対象読者: 開発者・運用担当者
+> prod 環境への初回デプロイ手順と、継続的デプロイの説明を記載する。
+
+---
+
+## 前提条件
+
+以下のツールがインストールされていること:
+
+| ツール | バージョン目安 | 用途 |
+|-------|-------------|------|
+| AWS CLI | v2 | AWS リソース操作・確認 |
+| Docker / Docker Compose | 最新版 | Terraform 実行 |
+| gh CLI | 最新版 | GitHub Secrets 設定 |
+| git | 2.x | リポジトリ操作 |
+
+AWS 認証情報が設定済みであること（`~/.aws/credentials` または環境変数）。
+
+---
+
+## 初回デプロイ手順
+
+### ステップ 1: Terraform バックエンドの準備
+
+Terraform のリモートステートを保存する S3 バケットと DynamoDB テーブルを事前に作成しておく:
+
+```bash
+# S3 バケット（バージョニング有効）
+aws s3api create-bucket \
+  --bucket health-logger-tfstate-prod \
+  --region ap-northeast-1 \
+  --create-bucket-configuration LocationConstraint=ap-northeast-1
+
+aws s3api put-bucket-versioning \
+  --bucket health-logger-tfstate-prod \
+  --versioning-configuration Status=Enabled
+
+# DynamoDB（ロック用）
+aws dynamodb create-table \
+  --table-name health-logger-tflock-prod \
+  --attribute-definitions AttributeName=LockID,AttributeType=S \
+  --key-schema AttributeName=LockID,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region ap-northeast-1
+```
+
+### ステップ 2: terraform.tfvars の設定
+
+```bash
+cd terraform/envs/prod
+```
+
+`terraform.tfvars` に以下を設定する（シークレット値はここに書かない）:
+
+```hcl
+project            = "health-logger"
+env                = "prod"
+aws_region         = "ap-northeast-1"
+github_repository  = "your-org/health-logger"
+
+# 初回は localhost を指定（Amplify URL 確定後に更新）
+cognito_callback_urls = ["https://localhost:3000"]
+cors_allow_origins    = ["https://localhost:3000"]
+```
+
+VAPID キーは環境変数で渡す（tfvars に書かない）:
+
+```bash
+export TF_VAR_vapid_private_key="<VAPID秘密鍵>"
+export TF_VAR_vapid_public_key="<VAPID公開鍵>"
+```
+
+VAPID キーの生成方法（未生成の場合）:
+
+```bash
+docker run --rm node:20-slim npx web-push generate-vapid-keys
+```
+
+生成したキーは `~/.secrets/health-logger/vapid-keys.txt` に保存しておく（パーミッション 600）。
+
+### ステップ 3: Terraform init と初回 apply
+
+```bash
+BASE="docker compose -f docker-compose.terraform.yml run --rm terraform -chdir=terraform/envs/prod"
+
+# 初期化
+$BASE init
+
+# 検証
+$BASE validate
+
+# プラン確認（Lambda ZIP はまだないのでプレースホルダを指定）
+$BASE plan \
+  -var='lambda_s3_keys={"create_record":"placeholder","get_latest":"placeholder","push_subscribe":"placeholder","push_notify":"placeholder","get_item_config":"placeholder","save_item_config":"placeholder","delete_record":"placeholder","get_env_data":"placeholder","get_env_data_latest":"placeholder"}'
+```
+
+問題がなければ apply を実行する（必ずユーザーが手動で確認してから実行すること）:
+
+```bash
+$BASE apply \
+  -var='lambda_s3_keys={"create_record":"placeholder","get_latest":"placeholder","push_subscribe":"placeholder","push_notify":"placeholder","get_item_config":"placeholder","save_item_config":"placeholder","delete_record":"placeholder","get_env_data":"placeholder","get_env_data_latest":"placeholder"}'
+```
+
+### ステップ 4: Terraform 出力値の確認
+
+```bash
+$BASE output
+```
+
+以下の値を記録しておく:
+
+| 出力キー | 説明 |
+|---------|------|
+| `amplify_app_url` | Amplify のデプロイ URL（`https://main.XXXX.amplifyapp.com`） |
+| `lambda_artifacts_bucket` | Lambda ZIP 保存用 S3 バケット名 |
+| `github_actions_role` | GitHub OIDC ロール ARN |
+| `api_endpoint` | API Gateway のエンドポイント URL |
+| `cognito_user_pool_id` | Cognito ユーザープール ID |
+| `cognito_client_id` | Cognito クライアント ID |
+
+### ステップ 5: GitHub Secrets の設定
+
+```bash
+gh secret set AWS_ROLE_ARN_PROD --body "<github_actions_role の値>"
+gh secret set LAMBDA_ARTIFACTS_BUCKET_PROD --body "<lambda_artifacts_bucket の値>"
+gh secret set AMPLIFY_APP_ID_PROD --body "<amplify_app_url から取得した App ID>"
+gh secret set VAPID_PRIVATE_KEY_PROD --body "<VAPID秘密鍵>"
+```
+
+> VAPID 秘密鍵は GitHub Secrets に設定するのみ。コード・PR・チャットには絶対に書かない。
+> 過去に PR 説明文に誤記載してしまった事故がある（その際は即時鍵再生成で対応した）。
+
+### ステップ 6: Amplify GitHub 接続の確認
+
+1. AWS Console → Amplify を開く
+2. 作成されたアプリを選択
+3. 「リポジトリを接続」または「ブランチを管理」から GitHub App OAuth で接続を確認する
+4. GitHub App 経由の接続が確立していれば PAT（GitHub Personal Access Token）は不要
+
+接続が表示されない場合は「リポジトリを再接続」から GitHub App OAuth フローで再接続する。
+
+### ステップ 7: Cognito callback_urls と CORS を本番値に更新
+
+`terraform.tfvars` を更新する:
+
+```hcl
+cognito_callback_urls = ["https://main.XXXX.amplifyapp.com"]
+cors_allow_origins    = ["https://main.XXXX.amplifyapp.com"]
+```
+
+再度 apply を実行する（必ずユーザーが確認してから）:
+
+```bash
+$BASE apply
+```
+
+> `cors_allow_origins = ["*"]` のまま本番運用しない。Amplify の実際のドメインに必ず制限すること。
+
+### ステップ 8: main ブランチへの push でデプロイ確認
+
+```bash
+git push origin main
+```
+
+GitHub Actions の `deploy.yml` が起動し、以下が自動実行される:
+1. Lambda ZIP のビルドと S3 へのアップロード
+2. `terraform apply`（Lambda の実コードを参照した S3 キーを使用）
+3. Amplify の自動ビルド（GitHub push に連動）
+
+---
+
+## 継続的デプロイ（通常の開発フロー）
+
+`main` ブランチへの push が発生すると自動デプロイが実行される。
+
+### 変更検知による最適化
+
+`deploy.yml` は変更パスを検知し、不要なステップをスキップする:
+
+| 変更パス | Lambda ビルド | Terraform apply | Amplify ビルド |
+|---------|-------------|----------------|---------------|
+| `lambda/**` のみ | 実行 | 実行 | スキップ |
+| `terraform/**` のみ | 実行 | 実行 | スキップ |
+| `frontend/**` のみ | スキップ | スキップ | 実行（GitHub push で自動） |
+
+### デプロイ状況の確認
+
+```bash
+# GitHub Actions の実行履歴を確認
+gh run list --workflow=deploy.yml
+
+# 特定の実行の詳細
+gh run view <run-id>
+```
+
+---
+
+## Iceberg スキーマ変更後の ALTER TABLE 手順
+
+Glue テーブルにカラムを追加した後は、Athena で DDL を手動実行すること。
+
+```bash
+aws athena start-query-execution \
+  --query-string "ALTER TABLE health_records ADD COLUMNS (new_column_name string)" \
+  --query-execution-context Database=health_logger_prod_health_logs \
+  --result-configuration OutputLocation=s3://health-logger-prod/athena-results/ \
+  --region ap-northeast-1
+```
+
+クエリの実行状態を確認する:
+
+```bash
+aws athena get-query-execution \
+  --query-execution-id <上記コマンドで返された QueryExecutionId> \
+  --region ap-northeast-1
+```
+
+`State` が `SUCCEEDED` になれば完了。
+
+> この手順を省略すると `get_latest` Lambda が `COLUMN_NOT_FOUND` エラーで全件 500 になる。
+> 詳細は `DATABASE_SCHEMA.md` の「Iceberg スキーマ変更の注意事項」を参照。
+
+---
+
+## Amplify GitHub 接続の再接続手順
+
+Amplify と GitHub の接続が切れた場合（定期的な認証期限切れなどで発生する）:
+
+1. AWS Console → Amplify → 該当アプリを選択
+2. 「アプリの設定」→「リポジトリを管理」
+3. 「リポジトリを再接続」ボタンをクリック
+4. GitHub App OAuth フローで再認証する
+
+Terraform 側は `lifecycle { ignore_changes = [access_token] }` を設定しているため、
+Console から接続を変更しても terraform の状態は影響を受けない。
+
+---
+
+## ロールバック手順
+
+### Lambda のロールバック
+
+特定のコミット SHA の ZIP がまだ S3 に残っている場合、そのキーを指定して apply する:
+
+```bash
+PREV_SHA="<ロールバック先のコミット SHA>"
+$BASE apply \
+  -var="lambda_s3_keys={\"create_record\":\"create_record/${PREV_SHA}.zip\",\"get_latest\":\"get_latest/${PREV_SHA}.zip\",...}"
+```
+
+### フロントエンドのロールバック
+
+Amplify Console から以前のデプロイを再デプロイできる:
+
+1. AWS Console → Amplify → 該当ブランチ
+2. 「デプロイ履歴」から対象のデプロイを選択
+3. 「再デプロイ」ボタンをクリック
+
+### Terraform のロールバック
+
+Terraform のリモートステートは S3 でバージョン管理されているため、過去のステートを参照可能。
+ただし、Terraform によるロールバックはリソースの破壊・再作成を伴う場合があるため、
+実施前にプランを十分に確認すること。

--- a/docs/FRONTEND_DEVELOPMENT.md
+++ b/docs/FRONTEND_DEVELOPMENT.md
@@ -1,0 +1,274 @@
+# フロントエンド開発ガイド
+
+> 対象読者: 開発者
+> React + TypeScript PWA のローカル開発・認証・型定義・PWA 構成を記載する。
+
+---
+
+## 開発環境のセットアップ
+
+```bash
+cd frontend
+npm install
+```
+
+### ローカル開発サーバーの起動
+
+```bash
+npm run dev
+```
+
+`http://localhost:5173` でアクセスできる（Vite のデフォルトポート）。
+
+### 本番ビルド
+
+```bash
+npm run build
+# dist/ にビルド成果物が出力される
+```
+
+### 型チェックのみ実行
+
+```bash
+npx tsc --noEmit
+```
+
+---
+
+## TypeScript strict モードの開発方針
+
+`tsconfig.json` に `"strict": true` を設定している。この設定は緩めないこと。
+
+strict モードで特に注意が必要な点:
+
+**null / undefined の扱い**
+
+```typescript
+// NG: null かもしれない値を直接使う
+const token = session.tokens?.idToken?.toString()
+apiCall(token)  // token が null の可能性がある
+
+// OK: 明示的に null チェックする
+const token = session.tokens?.idToken?.toString() ?? null
+if (!token) return
+apiCall(token)
+```
+
+**環境変数のキャスト**
+
+```typescript
+// OK: VITE_ プレフィックスで参照し、as string でキャスト
+const endpoint = import.meta.env.VITE_API_ENDPOINT as string
+
+// NG: process.env を使わない（Vite では動作しない）
+// NG: import.meta.env.VITE_XXX をキャストなしで string に渡す
+```
+
+---
+
+## Amplify Auth の使い方
+
+### 初期設定（main.tsx）
+
+```typescript
+import { Amplify } from 'aws-amplify'
+
+Amplify.configure({
+  Auth: {
+    Cognito: {
+      userPoolId: import.meta.env.VITE_COGNITO_USER_POOL_ID as string,
+      userPoolClientId: import.meta.env.VITE_COGNITO_CLIENT_ID as string,
+      loginWith: {
+        oauth: {
+          domain: import.meta.env.VITE_COGNITO_DOMAIN as string,
+          scopes: ['openid', 'email', 'profile'],
+          redirectSignIn: [window.location.origin],
+          redirectSignOut: [window.location.origin],
+          responseType: 'code',
+        },
+      },
+    },
+  },
+})
+```
+
+### useAuth フックの使い方
+
+`frontend/src/hooks/useAuth.ts` に認証ロジックを集約している。
+
+```typescript
+import { useAuth } from './hooks/useAuth'
+
+function App() {
+  const { isAuthenticated, token, loading, signIn, signOut } = useAuth()
+
+  if (loading) return <LoadingSpinner />
+  if (!isAuthenticated) return <button onClick={signIn}>ログイン</button>
+
+  // token は Cognito ID Token（API リクエストの Authorization ヘッダーに使用）
+  return <HealthForm token={token!} />
+}
+```
+
+**`useAuth` の内部動作**:
+1. マウント時に `fetchAuthSession()` でセッション確認
+2. `idToken` が存在すれば認証済みと判定（`accessToken` ではなく `idToken` を使用）
+3. `signIn()` は `signInWithRedirect()` を呼び出し、Cognito Hosted UI にリダイレクト
+4. Amplify ライブラリがトークンの自動リフレッシュを担当
+
+### サブパスインポートの注意
+
+```typescript
+// OK: サブパスインポートを使う
+import { fetchAuthSession, signInWithRedirect, signOut } from 'aws-amplify/auth'
+import { Amplify } from 'aws-amplify'
+
+// NG: 古い形式（バンドルサイズが増大する）
+// import { Auth } from 'aws-amplify'
+```
+
+---
+
+## useOfflineQueue フック
+
+オフライン時に体調記録を IndexedDB に保存し、オンライン復帰後に自動送信する。
+
+**`frontend/src/hooks/useOfflineQueue.ts`** に実装が集約されている。コンポーネントから IndexedDB を直接操作しないこと。
+
+### 使い方
+
+```typescript
+import { useOfflineQueue } from './hooks/useOfflineQueue'
+
+function HealthForm({ token, apiEndpoint }: Props) {
+  const { enqueue, flush } = useOfflineQueue(apiEndpoint)
+
+  // オフライン時: IndexedDB に保存
+  const handleSubmit = async (record: HealthRecordInput) => {
+    if (!navigator.onLine) {
+      await enqueue(record, token)
+      return
+    }
+    await fetch(`${apiEndpoint}/records`, { /* ... */ })
+  }
+
+  // オンライン復帰時: キューを送信
+  useEffect(() => {
+    const handleOnline = () => flush(token)
+    window.addEventListener('online', handleOnline)
+    return () => window.removeEventListener('online', handleOnline)
+  }, [flush, token])
+}
+```
+
+### 内部の仕組み
+
+```
+IndexedDB
+  データベース名: health_logger_db (v2)
+  オブジェクトストア: offline_queue
+    キー: id (autoIncrement)
+    インデックス: timestamp
+    レコード: { url, body, token, timestamp }
+```
+
+**enqueue**: 記録を IndexedDB に追加する。
+**flush**: IndexedDB の全エントリを順番に送信し、成功したものを削除する。失敗したものは次回の flush まで残る。
+
+---
+
+## PWA / Service Worker の仕組み
+
+`frontend/public/sw.js` にサービスワーカーが定義されている。
+
+**主な機能**:
+- オフライン時の静的ファイルキャッシュ（App Shell パターン）
+- Web Push 通知の受信処理
+
+**登録方法（main.tsx）**:
+
+```typescript
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js')
+}
+```
+
+**Web Push 通知のフロー**:
+
+```
+ブラウザ → VAPID 公開鍵で購読作成 → POST /push/subscribe → DynamoDB 保存
+↓（毎日スケジューラーから）
+EventBridge → push_notify Lambda → DynamoDB スキャン → Web Push 送信
+↓
+ブラウザの Service Worker → 通知表示
+```
+
+VAPID 公開鍵は Amplify の環境変数 `VITE_VAPID_PUBLIC_KEY` から参照する。
+
+---
+
+## 型定義（types.ts）の拡張手順
+
+`frontend/src/types.ts` に共有型定義を集約している。
+
+**既存の型**:
+
+```typescript
+// 記録種別と入力モードの制約
+type ItemType = 'slider' | 'checkbox' | 'number' | 'text'
+type ItemMode = 'form' | 'event' | 'status'
+
+// カスタム項目の設定
+interface ItemConfig { ... }
+
+// カスタム項目の値（記録時）
+interface CustomFieldValue { ... }
+
+// POST /records のリクエストボディ
+interface HealthRecordInput { ... }
+
+// GET /records/latest のレスポンス要素
+// 注意: Athena はすべての値を string で返す
+interface LatestRecord { ... }
+```
+
+**新しいカスタム項目の type を追加する場合**:
+
+1. `types.ts` の `ItemType` に値を追加する
+2. `lambda/create_record/models.py` の `CustomFieldValue.type` の `Literal` に追加する
+3. `lambda/save_item_config/handler.py` の `ALLOWED_TYPES` に追加する
+
+3ファイルを合わせて変更しないと、フロントエンドとバックエンドで型が食い違う。
+
+---
+
+## ローカルでの Cognito 設定
+
+ローカル開発でも Cognito 認証を使うには、Terraform で callback_urls に `http://localhost:5173` を追加する必要がある。
+
+**手順**:
+
+1. `terraform/envs/prod/terraform.tfvars` に localhost を追加する:
+
+```hcl
+cognito_callback_urls = [
+  "https://main.XXXX.amplifyapp.com",
+  "http://localhost:5173"
+]
+```
+
+2. terraform apply を実行する（ユーザーが確認してから）
+
+3. `frontend/` に `.env.local` を作成する:
+
+```
+VITE_API_ENDPOINT=https://<api-id>.execute-api.ap-northeast-1.amazonaws.com
+VITE_COGNITO_USER_POOL_ID=ap-northeast-1_XXXXXXXXX
+VITE_COGNITO_CLIENT_ID=XXXXXXXXXXXXXXXXXXXXXXXXXX
+VITE_COGNITO_DOMAIN=health-logger-prod.auth.ap-northeast-1.amazoncognito.com
+VITE_VAPID_PUBLIC_KEY=BXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...
+```
+
+これらの値は `terraform output` コマンドで確認できる。
+
+`.env.local` は `.gitignore` に含まれているため、コミットされない。

--- a/docs/LAMBDA_DEVELOPMENT.md
+++ b/docs/LAMBDA_DEVELOPMENT.md
@@ -1,0 +1,372 @@
+# Lambda 開発ガイド
+
+> 対象読者: 開発者
+> Python Lambda 関数の実装パターン・テスト方法・追加手順を記載する。
+
+---
+
+## Lambda 関数の構成
+
+各 Lambda は `lambda/<function_name>/` ディレクトリに格納する。
+
+```
+lambda/
+  create_record/
+    __init__.py          # パッケージ初期化（空でよい）
+    handler.py           # Lambda ハンドラー関数
+    models.py            # Pydantic v2 モデル定義（handler.py に書かない）
+    requirements.txt     # 本番依存パッケージ
+    conftest.py          # pytest フィクスチャ
+    test_handler.py      # pytest テスト
+  get_latest/
+    __init__.py
+    handler.py
+    requirements.txt
+    conftest.py
+    test_handler.py
+  ...
+```
+
+**基本原則**:
+- `handler.py` にはリクエスト処理のロジックのみ書く
+- 型定義・バリデーションは `models.py` に分離する
+- テストは同ディレクトリの `test_handler.py` に書く
+
+---
+
+## handler.py の実装パターン
+
+### 標準的なハンドラーの構造
+
+```python
+import json
+import os
+import re
+
+import boto3
+from pydantic import ValidationError
+
+from models import MyInput
+
+# boto3 クライアントはモジュールレベルで初期化（Lambda のウォームスタートで再利用される）
+firehose = boto3.client("firehose")
+STREAM_NAME = os.environ["FIREHOSE_STREAM_NAME"]
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+def lambda_handler(event, context):
+    # 1. 認証: Cognito sub を取り出す
+    try:
+        user_id = event["requestContext"]["authorizer"]["jwt"]["claims"]["sub"]
+    except (KeyError, TypeError):
+        return _json(401, {"error": "Unauthorized"})
+
+    # 2. user_id のバリデーション（SQL インジェクション防止）
+    if not _UUID_RE.match(user_id):
+        return _json(401, {"error": "Invalid user ID"})
+
+    # 3. リクエストボディのパース
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return _json(400, {"error": "Invalid JSON"})
+
+    # 4. Pydantic バリデーション
+    try:
+        data = MyInput(**body)
+    except ValidationError as e:
+        return _json(400, {"error": "Validation failed", "details": e.errors()})
+
+    # 5. ビジネスロジック
+    ...
+
+    return _json(200, {"message": "OK"})
+
+
+def _json(status: int, body: dict) -> dict:
+    """エラーレスポンスの統一ヘルパー。内部スタックトレースは含めない。"""
+    return {
+        "statusCode": status,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }
+```
+
+### 重要なルール
+
+**boto3 クライアントはモジュールレベルで初期化する**
+
+```python
+# OK: ウォームスタート時にセッションを再利用できる
+firehose = boto3.client("firehose")
+
+def lambda_handler(event, context):
+    firehose.put_record(...)  # モジュール変数を使う
+
+# NG: 毎回コールドスタートと同じコストになる
+def lambda_handler(event, context):
+    firehose = boto3.client("firehose")  # 関数内で初期化しない
+```
+
+**user_id は必ず UUID 正規表現で検証する**
+
+Athena クエリに `user_id` を f-string で埋め込むため、SQL インジェクション防止のために必須:
+
+```python
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+if not _UUID_RE.match(user_id):
+    return _json(401, {"error": "Invalid user ID"})
+
+# UUID 検証済みのため f-string に埋め込んでよい
+query = f"SELECT * FROM health_records WHERE user_id = '{user_id}'"
+```
+
+---
+
+## models.py の定義パターン
+
+Pydantic v2 を使用する。バリデーションロジックは `models.py` に集約する。
+
+```python
+from typing import Literal, Optional, Union
+from pydantic import BaseModel, Field
+
+
+class CustomFieldValue(BaseModel):
+    item_id: str
+    label:   str
+    type:    Literal["slider", "checkbox", "number", "text"]
+    value:   Union[int, float, bool, str]
+
+
+class HealthRecordInput(BaseModel):
+    # 必須フィールド
+    recorded_at: str = Field(...)
+
+    # オプション（デフォルト値付き）
+    record_type:      Literal["daily", "event", "status"] = Field("daily")
+    fatigue_score:    Optional[int] = Field(None, ge=0, le=100)
+    mood_score:       Optional[int] = Field(None, ge=0, le=100)
+    motivation_score: Optional[int] = Field(None, ge=0, le=100)
+    flags:            int  = Field(0,  ge=0, le=63)
+    note:             str  = Field("", max_length=280)
+    timezone:         str  = Field("UTC")
+    device_id:        str  = Field("")
+    app_version:      str  = Field("1.0.0")
+    custom_fields:    list[CustomFieldValue] = Field(default_factory=list)
+```
+
+`Field(...)` は必須フィールドを示す（`...` は Pydantic の「必須」記法）。
+
+---
+
+## 環境変数の管理
+
+Lambda の環境変数は `os.environ` で参照する。Terraform の `modules/lambda/` で定義する。
+
+```python
+import os
+
+# 必須の環境変数（存在しなければ起動時にクラッシュする → 意図的な早期失敗）
+STREAM_NAME   = os.environ["FIREHOSE_STREAM_NAME"]
+DATABASE      = os.environ["ATHENA_DATABASE"]
+OUTPUT_BUCKET = os.environ["ATHENA_OUTPUT_BUCKET"]
+
+# 任意の環境変数（デフォルト値付き）
+TABLE = os.environ.get("ATHENA_TABLE", "health_records")
+```
+
+**テスト時の環境変数設定**は `conftest.py` で行う:
+
+```python
+import os
+import pytest
+
+@pytest.fixture(autouse=True)
+def env_vars(monkeypatch):
+    monkeypatch.setenv("FIREHOSE_STREAM_NAME", "test-stream")
+    monkeypatch.setenv("ATHENA_DATABASE", "test_db")
+    monkeypatch.setenv("ATHENA_OUTPUT_BUCKET", "test-bucket")
+```
+
+---
+
+## requirements.txt の構成
+
+本番で必要な依存パッケージのみ記載する（テスト用パッケージは含めない）。
+
+```
+# create_record/requirements.txt
+pydantic>=2.0,<3
+
+# get_latest/requirements.txt
+boto3  # Lambda 実行環境に含まれているが明示すると管理しやすい
+
+# push_notify/requirements.txt
+pywebpush>=2.0,<3
+```
+
+> AWS Lambda の Python 3.13 ランタイムには `boto3` が標準で含まれる。
+> ただし、バージョン固定が必要な場合は `requirements.txt` に記載する。
+
+---
+
+## ローカルテスト
+
+### pytest の実行
+
+```bash
+# 全 Lambda のテスト
+pytest lambda/ -v
+
+# 個別 Lambda のテスト
+pytest lambda/create_record/ -v
+pytest lambda/get_latest/ -v
+```
+
+### テストの書き方
+
+AWS サービス（Firehose・Athena・DynamoDB）は `unittest.mock.patch` でモック化する。
+
+```python
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+@pytest.fixture
+def valid_event():
+    return {
+        "requestContext": {
+            "authorizer": {
+                "jwt": {
+                    "claims": {"sub": "12345678-1234-1234-1234-123456789012"}
+                }
+            }
+        },
+        "body": json.dumps({
+            "fatigue_score": 60,
+            "mood_score": 70,
+            "motivation_score": 50,
+            "flags": 0,
+            "recorded_at": "2026-03-16T08:00:00+09:00",
+        }),
+    }
+
+
+@patch("handler.firehose")
+def test_create_record_success(mock_fh, valid_event):
+    mock_fh.put_record.return_value = {"RecordId": "xxx"}
+    from handler import lambda_handler
+    response = lambda_handler(valid_event, {})
+    assert response["statusCode"] == 201
+    body = json.loads(response["body"])
+    assert "record_id" in body
+
+
+def test_missing_auth():
+    """認証情報がない場合は 401 を返す"""
+    event = {"body": json.dumps({"recorded_at": "2026-03-16T08:00:00+09:00"})}
+    from handler import lambda_handler
+    response = lambda_handler(event, {})
+    assert response["statusCode"] == 401
+
+
+def test_validation_error(valid_event):
+    """バリデーションエラー（範囲外の値）は 400 を返す"""
+    import json
+    body = json.loads(valid_event["body"])
+    body["fatigue_score"] = 999  # 100 を超える
+    valid_event["body"] = json.dumps(body)
+    from handler import lambda_handler
+    response = lambda_handler(valid_event, {})
+    assert response["statusCode"] == 400
+```
+
+**カバレッジ目標**: 正常系・バリデーションエラー・AWS エラー（モック）の 3 パターンを最低限カバーする。
+
+---
+
+## 新規 Lambda 関数の追加手順
+
+### 1. Lambda ディレクトリの作成
+
+```bash
+mkdir -p lambda/my_new_function
+touch lambda/my_new_function/__init__.py
+touch lambda/my_new_function/handler.py
+touch lambda/my_new_function/requirements.txt
+touch lambda/my_new_function/test_handler.py
+```
+
+### 2. handler.py と requirements.txt の実装
+
+上記の「handler.py の実装パターン」を参考に実装する。
+
+### 3. terraform/modules/lambda/ の更新
+
+`terraform/modules/lambda/main.tf` に新しい Lambda リソースを追加する。
+
+```hcl
+resource "aws_lambda_function" "my_new_function" {
+  function_name = "${var.project}-${var.env}-my-new-function"
+  role          = aws_iam_role.lambda_exec.arn
+  runtime       = "python3.13"
+  handler       = "handler.lambda_handler"
+  s3_bucket     = aws_s3_bucket.artifacts.bucket
+  s3_key        = var.lambda_s3_keys["my_new_function"]
+  timeout       = 30
+  environment {
+    variables = {
+      # 必要な環境変数を定義
+    }
+  }
+}
+```
+
+`variables.tf` の `lambda_s3_keys` に新しいキーを追加する。
+
+### 4. terraform/modules/apigw/ の更新
+
+API Gateway に新しいルートを追加する（HTTP API の場合）:
+
+```hcl
+resource "aws_apigatewayv2_integration" "my_new_function" {
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = var.my_new_function_lambda_invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "my_new_function" {
+  api_id             = aws_apigatewayv2_api.main.id
+  route_key          = "GET /my-endpoint"
+  target             = "integrations/${aws_apigatewayv2_integration.my_new_function.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.cognito.id
+}
+```
+
+### 5. deploy.yml の更新
+
+`.github/workflows/deploy.yml` の「Build Lambda ZIPs」ジョブに新しい関数のパッケージ手順を追加する:
+
+```yaml
+- name: Package my_new_function Lambda
+  run: |
+    cd lambda/my_new_function
+    pip install -r requirements.txt -t . --quiet
+    zip -r ../../my_new_function.zip . -x "test_*" "*.pyc" "__pycache__/*"
+```
+
+また、アップロードと outputs にも追加する。
+
+### 6. terraform/envs/prod/main.tf の更新
+
+`module "apigw"` ブロックに新しい Lambda の invoke_arn と function_name を渡す。

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,13 @@
 
 | ファイル | 内容 | 主な読者 |
 |---------|------|---------|
+| `API_REFERENCE.md` | 全 API エンドポイント仕様（8 エンドポイント） | 開発者 |
+| `DATABASE_SCHEMA.md` | S3 Tables (Iceberg) / DynamoDB のスキーマ定義 | 開発者・データエンジニア |
+| `DEPLOYMENT_GUIDE.md` | 初回デプロイ・継続的デプロイ・ロールバック手順 | 開発者・運用担当者 |
+| `LAMBDA_DEVELOPMENT.md` | Lambda の実装パターン・テスト・新規追加手順 | 開発者 |
+| `FRONTEND_DEVELOPMENT.md` | React/TS 開発・Amplify Auth・PWA 構成 | 開発者 |
+| `DBT_OPERATIONS.md` | dbt 実行方法・モデル構成・スキーマ変更手順 | 開発者・データエンジニア |
+| `TROUBLESHOOTING.md` | よくあるエラーと対処集 | 開発者・運用担当者 |
 | `claude-code-usage.md` | Claude Code の使い方・Agent Teams の起動方法 | 開発者（AI コーディング） |
 | `github-tokens.md` | GitHub トークンの管理方法 | 開発者 |
 | `infrastructure.drawio` | インフラ構成図（draw.io 形式） | 開発者・アーキテクト |
@@ -90,8 +97,17 @@ AI コーディング時も意識して指示する必要がある:
 ## よくある質問（FAQ）
 
 ### Q: ローカルで動作確認できる？
-→ `docs/claude-code-usage.md` の「ローカル確認方法」を参照。  
+→ `FRONTEND_DEVELOPMENT.md` の「ローカルでの Cognito 設定」を参照。
 Cognito callback URL に localhost を追加する設定変更が必要。
+
+### Q: API の仕様を確認したい
+→ `API_REFERENCE.md` を参照。リクエスト・レスポンスの JSON スキーマがまとまっている。
+
+### Q: Lambda を新しく追加したい
+→ `LAMBDA_DEVELOPMENT.md` の「新規 Lambda 関数の追加手順」を参照。
+
+### Q: 本番デプロイの手順を確認したい
+→ `DEPLOYMENT_GUIDE.md` を参照。初回デプロイから Amplify 接続まで手順が記載されている。
 
 ### Q: データが消えた場合の対応は？
 → 現状 S3 Iceberg のバックアップ未設定。`non-functional-requirements.md` のバックアップセクション参照。
@@ -100,4 +116,12 @@ Cognito callback URL に localhost を追加する設定変更が必要。
 → AWS Cost Explorer で原因サービスを特定。`cost-management.md` のリスクシナリオを参照。
 
 ### Q: 新しい記録項目を追加したい場合は？
-→ Iceberg スキーマ変更が必要。`data-lineage.md` のスキーマ変更手順と CLAUDE.md の「Iceberg スキーマ変更の注意事項」を参照。
+→ Iceberg スキーマ変更が必要。`DATABASE_SCHEMA.md` の「Iceberg スキーマ変更の注意事項」と
+`DEPLOYMENT_GUIDE.md` の「Iceberg スキーマ変更後の ALTER TABLE 手順」を参照。
+
+### Q: エラーが発生した場合は？
+→ `TROUBLESHOOTING.md` を参照。COLUMN_NOT_FOUND・クエリタイムアウト・認証ループなどの
+対処法がまとまっている。
+
+### Q: dbt を実行したい
+→ `DBT_OPERATIONS.md` を参照。Docker Compose での実行方法とコマンドリファレンスが記載されている。

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,292 @@
+# トラブルシューティング
+
+> 対象読者: 開発者・運用担当者
+> よくあるエラーと対処方法をまとめる。新しいエラーが発生したら追記すること。
+
+---
+
+## Lambda / API エラー
+
+### COLUMN_NOT_FOUND（get_latest が 500 を返す）
+
+**症状**: `GET /records/latest` が全件 500 エラーを返す。CloudWatch ログに
+`COLUMN_NOT_FOUND` や `Column 'xxx' cannot be resolved` が記録されている。
+
+**原因**: Glue カタログにカラムを追加したが、S3 上の Iceberg メタデータに反映されていない。
+`terraform apply` だけでは Iceberg メタデータは更新されない。
+
+**対処**: Athena で ALTER TABLE を実行する:
+
+```bash
+aws athena start-query-execution \
+  --query-string "ALTER TABLE health_records ADD COLUMNS (new_column_name string)" \
+  --query-execution-context Database=health_logger_prod_health_logs \
+  --result-configuration OutputLocation=s3://health-logger-prod/athena-results/ \
+  --region ap-northeast-1
+```
+
+実行後に状態を確認:
+
+```bash
+aws athena get-query-execution \
+  --query-execution-id <QueryExecutionId> \
+  --region ap-northeast-1
+```
+
+`"State": "SUCCEEDED"` になれば修正完了。
+
+**過去の事例**: PR #16 で `record_type` / `custom_fields` カラムを追加した際に発生。
+本番で全リクエストが 500 エラーになり、ALTER TABLE で修正した。
+
+---
+
+### Query timeout（504）
+
+**症状**: `GET /records/latest` や `DELETE /records/{id}` が 504 を返す。
+
+**原因候補**:
+1. Athena クエリが 10 秒以内に完了しなかった
+2. パーティションプルーニングが効いていない（大量データのフルスキャン）
+3. Iceberg メタデータの肥大化
+
+**対処 1: パーティションプルーニングの確認**
+
+`get_latest` Lambda のクエリは `WHERE user_id = '...'` のみで `dt` による絞り込みをしていない。
+大量のデータが蓄積されている場合、クエリに `dt` 条件を追加することを検討する:
+
+```sql
+-- dt を追加することでスキャン量を削減できる
+SELECT ... FROM health_records
+WHERE user_id = '...'
+  AND dt >= '2026-01-01'
+ORDER BY recorded_at DESC
+LIMIT 10
+```
+
+**対処 2: Athena の過去クエリ履歴を確認**
+
+```bash
+aws athena list-query-executions \
+  --work-group primary \
+  --region ap-northeast-1
+```
+
+実行時間が長いクエリを特定し、プランを確認する。
+
+**対処 3: 一時的な問題の場合**
+
+Athena は AWS のマネージドサービスのため、稀に一時的な遅延が発生する。
+数分後にリトライして改善されるか確認する。
+
+---
+
+### Lambda が起動しない（プレースホルダー ZIP の問題）
+
+**症状**: Lambda 関数が `InvalidParameterValueException` や起動エラーを返す。
+
+**原因**: `lambda_s3_keys` にプレースホルダー値（`"placeholder"`）を使って
+`terraform apply` した後、実際の ZIP がアップロードされていない。
+
+**対処**: GitHub Actions の `deploy.yml` を実行して実際の ZIP をアップロードし、
+Terraform を再 apply する。手動で実行する場合:
+
+```bash
+cd lambda/create_record
+pip install -r requirements.txt -t . --quiet
+zip -r ../../create_record.zip . -x "test_*" "*.pyc" "__pycache__/*"
+
+SHA=$(git rev-parse HEAD)
+aws s3 cp create_record.zip \
+  "s3://${LAMBDA_ARTIFACTS_BUCKET}/create_record/${SHA}.zip"
+```
+
+---
+
+## フロントエンド / 認証エラー
+
+### Cognito ログインが redirect ループになる
+
+**症状**: Cognito Hosted UI でログインすると、同じログイン画面に戻り続ける。
+
+**原因候補**:
+1. `callback_urls`（Cognito の許可リダイレクト先）に現在のドメインが含まれていない
+2. `CORS`（`cors_allow_origins`）に現在のドメインが含まれていない
+3. Amplify の設定（`main.tsx`）のドメイン・クライアント ID が間違っている
+
+**対処 1: callback_urls の確認**
+
+```bash
+aws cognito-idp describe-user-pool-client \
+  --user-pool-id ap-northeast-1_XXXXXXXXX \
+  --client-id XXXXXXXXXXXXXXXXXXXXXXXXXX \
+  --region ap-northeast-1 \
+  --query 'UserPoolClient.CallbackURLs'
+```
+
+現在アクセスしているドメインが含まれているか確認する。
+含まれていない場合は `terraform.tfvars` の `cognito_callback_urls` に追加して apply する。
+
+**対処 2: Amplify 環境変数の確認**
+
+AWS Console → Amplify → 該当アプリ → 「環境変数」で
+`VITE_COGNITO_CLIENT_ID` などが正しく設定されているか確認する。
+
+**対処 3: ブラウザの Cookie / localStorage のクリア**
+
+開発ツールで `localhost:5173` の localStorage と Cookie を削除してから再試行する。
+
+---
+
+### オフラインキューが溜まる（IndexedDB のデータが送信されない）
+
+**症状**: オフライン中に記録したデータが、オンライン復帰後も送信されない。
+
+**原因候補**:
+1. `flush()` が呼ばれていない（`online` イベントのリスナーが登録されていない）
+2. API リクエストが認証エラーで失敗している（トークン期限切れ）
+3. IndexedDB のストレージ容量が上限に達している
+
+**対処 1: キューの内容を確認する**
+
+ブラウザの開発ツール → Application → IndexedDB → `health_logger_db` → `offline_queue` を確認する。
+
+**対処 2: キューを手動でクリアする**
+
+```javascript
+// ブラウザのコンソールで実行
+const req = indexedDB.open('health_logger_db', 2)
+req.onsuccess = (e) => {
+  const db = e.target.result
+  const tx = db.transaction('offline_queue', 'readwrite')
+  tx.objectStore('offline_queue').clear()
+  console.log('キューをクリアしました')
+}
+```
+
+クリア後に再度記録を行うこと（データは失われる）。
+
+**対処 3: ストレージ容量の確認**
+
+```javascript
+// ブラウザのコンソールで実行
+navigator.storage.estimate().then(console.log)
+// quota: 利用可能な最大容量
+// usage: 現在の使用量
+```
+
+容量が上限に近い場合は、不要なデータを削除するかストレージをクリアする。
+
+---
+
+## Amplify / デプロイエラー
+
+### Amplify GitHub 接続が切れた
+
+**症状**: GitHub への push 後に Amplify のビルドが自動実行されない。
+AWS Console の Amplify でリポジトリ接続が「切断」状態になっている。
+
+**原因**: GitHub App の認証が期限切れ、またはリポジトリの権限変更。
+
+**対処**: AWS Console から再接続する:
+
+1. AWS Console → Amplify → 該当アプリを選択
+2. 「アプリの設定」→ 「リポジトリを管理」
+3. 「リポジトリを再接続」ボタンをクリック
+4. GitHub App OAuth フローで認証する（PAT は不要）
+
+> PAT（GitHub Personal Access Token）は使用しない。
+> GitHub App OAuth で接続すること。
+
+---
+
+### Amplify ビルドが失敗する（buildComputeType エラー）
+
+**症状**: Amplify ビルドが `The build compute type is not supported in this region` などのエラーで失敗する。
+
+**原因**: `ap-northeast-1` では `STANDARD_8GB` のみサポートされている。また、カスタムビルドコンピュートタイプを使用するには IAM サービスロールが必要。
+
+**対処**: Terraform の `modules/amplify/main.tf` で以下が設定されていることを確認する:
+- `build_spec` 内の `computeType` が `STANDARD_8GB`
+- Amplify サービスロール（`amplify.amazonaws.com` の trust policy）が設定されている
+
+---
+
+## dbt エラー
+
+### dbt run が失敗する（接続エラー）
+
+**症状**: `dbt run` を実行すると Athena への接続エラーが発生する。
+
+**原因候補**:
+1. `profiles.yml` が存在しない、または設定が間違っている
+2. AWS 認証情報が設定されていない
+3. S3 スタジングバケットへのアクセス権限がない
+
+**対処 1: profiles.yml の確認**
+
+```bash
+docker compose -f docker-compose.dbt.yml exec dbt cat /root/.dbt/profiles.yml
+```
+
+`DBT_OPERATIONS.md` の「profiles.yml の設定」セクションを参照して正しく設定する。
+
+**対処 2: 接続テスト**
+
+```bash
+docker compose -f docker-compose.dbt.yml exec dbt dbt debug
+```
+
+接続の各コンポーネント（profiles.yml の読み込み・Athena への接続・S3 へのアクセス）が
+`OK` になるか確認する。
+
+**対処 3: AWS 認証情報の確認**
+
+```bash
+docker compose -f docker-compose.dbt.yml exec dbt aws sts get-caller-identity
+```
+
+正しいアカウント・ユーザーが表示されるか確認する。
+
+---
+
+### dbt run で `relation already exists` エラー
+
+**症状**: `dbt run` で `Relation already exists` などのエラーが発生する。
+
+**原因**: インクリメンタルモデルの設定と実際のテーブル定義が不一致になっている。
+
+**対処**: フルリフレッシュで再作成する:
+
+```bash
+docker compose -f docker-compose.dbt.yml exec dbt dbt run --full-refresh --select <モデル名>
+```
+
+フルリフレッシュは既存テーブルを DROP して再作成する。本番環境での実行前に影響範囲を確認すること。
+
+---
+
+## Terraform エラー
+
+### terraform plan で `InvalidClientTokenId` / `AuthFailure`
+
+**症状**: `terraform plan` 実行時に AWS 認証エラーが発生する。
+
+**対処**: AWS 認証情報の設定を確認する:
+
+```bash
+aws sts get-caller-identity
+```
+
+認証情報が期限切れの場合は再設定する。MFA を使用している場合は一時クレデンシャルを取得する。
+
+### terraform apply で `BucketAlreadyOwnedByYou`
+
+**症状**: S3 バケットの作成で `BucketAlreadyOwnedByYou` エラー。
+
+**対処**: すでに同名のバケットが存在する。Terraform の state に import する:
+
+```bash
+docker compose -f docker-compose.terraform.yml run --rm terraform \
+  -chdir=terraform/envs/prod \
+  import aws_s3_bucket.example <バケット名>
+```

--- a/lambda/conftest.py
+++ b/lambda/conftest.py
@@ -4,3 +4,11 @@ import os
 # Add create_record to sys.path at collection time so module-level imports work
 # (create_record/test_handler.py imports `from models import HealthRecordInput` at top level)
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "create_record"))
+
+# get_env_data/ bundles its own pydantic/pydantic_core built for Python 3.13.
+# Running tests on Python <3.13 causes ModuleNotFoundError for the native extension.
+# Remove the bundled paths from sys.path so the system-installed pydantic is used instead.
+_get_env_data = os.path.join(os.path.dirname(__file__), "get_env_data")
+for _p in list(sys.path):
+    if _p.startswith(_get_env_data):
+        sys.path.remove(_p)

--- a/lambda/delete_record/test_handler.py
+++ b/lambda/delete_record/test_handler.py
@@ -62,3 +62,14 @@ def test_delete_query_failed(mock_athena):
     }
     resp = handler.lambda_handler(_event(), None)
     assert resp["statusCode"] == 500
+
+
+@patch.object(handler, "athena")
+def test_delete_timeout(mock_athena):
+    mock_athena.start_query_execution.return_value = {"QueryExecutionId": "qid"}
+    mock_athena.get_query_execution.return_value = {
+        "QueryExecution": {"Status": {"State": "RUNNING"}}
+    }
+    with patch("time.sleep"):  # sleep を skip
+        resp = handler.lambda_handler(_event(), None)
+    assert resp["statusCode"] == 504

--- a/lambda/get_env_data/conftest.py
+++ b/lambda/get_env_data/conftest.py
@@ -2,16 +2,39 @@
 
 This file is loaded by pytest before collecting any tests in this directory.
 It prepends get_env_data/ and its sub-packages to sys.path so that
-`from models import ...` resolves to get_env_data/models.py, not to
-other Lambda packages (e.g. create_record/models.py) that may already
-be on sys.path when running pytest from the lambda/ root.
+`from env_models import ...` resolves to get_env_data/env_models.py, not to
+other Lambda packages that may already be on sys.path when running pytest
+from the lambda/ root.
+
+Note: get_env_data/ bundles pydantic/pydantic_core built for Python 3.13.
+When running tests on Python <3.13 the native extension cannot load.
+We therefore pre-load the system pydantic into sys.modules before inserting
+_here into sys.path, so subsequent `import pydantic` calls use the cached
+system version rather than the bundled one.
 """
 import os
+import platform
 import sys
 
 _here = os.path.dirname(os.path.abspath(__file__))
 _clients = os.path.join(_here, "clients")
 _services = os.path.join(_here, "services")
+
+# Pre-load system pydantic when the bundled native extension is incompatible.
+_is_py313 = platform.python_version_tuple()[0:2] == ("3", "13")
+if not _is_py313:
+    # Temporarily exclude _here so that `import pydantic` picks up the system copy.
+    _saved = [p for p in sys.path if p == _here]
+    for _p in _saved:
+        sys.path.remove(_p)
+    try:
+        import pydantic  # noqa: F401 — populates sys.modules with system pydantic
+        import pydantic_core  # noqa: F401
+    except ImportError:
+        pass
+    # Restore _here after system pydantic is cached in sys.modules
+    for _p in _saved:
+        sys.path.insert(0, _p)
 
 for _p in (_services, _clients, _here):
     # Remove any existing occurrence so we can re-insert at position 0

--- a/lambda/get_item_config/test_handler.py
+++ b/lambda/get_item_config/test_handler.py
@@ -47,3 +47,43 @@ def test_get_existing_config(mock_table):
 def test_missing_auth():
     result = handler.lambda_handler({}, None)
     assert result["statusCode"] == 401
+
+
+# --- 追加テストケース ---
+
+VALID_USER = "12345678-1234-1234-1234-123456789abc"
+
+
+def _event(user_id=VALID_USER):
+    return {"requestContext": {"authorizer": {"jwt": {"claims": {"sub": user_id}}}}}
+
+
+@patch.object(handler, "table")
+def test_get_success(mock_table):
+    configs_data = [
+        {"item_id": "item1", "label": "疲労度", "type": "slider", "mode": "form"},
+        {"item_id": "item2", "label": "頭痛", "type": "checkbox", "mode": "event"},
+    ]
+    mock_table.get_item.return_value = {
+        "Item": {"user_id": VALID_USER, "configs": json.dumps(configs_data)}
+    }
+    resp = handler.lambda_handler(_event(), None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["configs"] == configs_data
+
+
+@patch.object(handler, "table")
+def test_get_empty(mock_table):
+    mock_table.get_item.return_value = {}
+    resp = handler.lambda_handler(_event(), None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["configs"] == []
+
+
+def test_unauthorized():
+    resp = handler.lambda_handler({}, None)
+    assert resp["statusCode"] == 401
+    body = json.loads(resp["body"])
+    assert "Unauthorized" in body["error"]

--- a/lambda/push_notify/test_handler.py
+++ b/lambda/push_notify/test_handler.py
@@ -1,0 +1,83 @@
+import importlib.util
+import json
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+os.environ.setdefault("PUSH_SUBSCRIPTIONS_TABLE", "test-subscriptions")
+os.environ.setdefault("VAPID_PRIVATE_KEY", "test-vapid-key")
+
+_spec = importlib.util.spec_from_file_location(
+    "push_notify_handler",
+    os.path.join(os.path.dirname(__file__), "handler.py"),
+)
+handler = importlib.util.module_from_spec(_spec)
+sys.modules["push_notify_handler"] = handler
+_spec.loader.exec_module(handler)
+
+from pywebpush import WebPushException
+
+VALID_SUBSCRIPTION = json.dumps(
+    {
+        "endpoint": "https://fcm.googleapis.com/fcm/send/dummy-endpoint",
+        "keys": {"p256dh": "key123", "auth": "auth456"},
+    }
+)
+
+
+def _make_item(user_id="uid-001"):
+    return {"user_id": user_id, "subscription": VALID_SUBSCRIPTION}
+
+
+@patch.object(handler, "webpush")
+@patch.object(handler, "table")
+def test_notify_success(mock_table, mock_webpush):
+    mock_table.scan.return_value = {"Items": [_make_item()]}
+    mock_webpush.return_value = None
+    result = handler.lambda_handler({}, None)
+    assert result["sent"] == 1
+    assert result["failed"] == 0
+    assert result["removed"] == 0
+
+
+@patch.object(handler, "webpush")
+@patch.object(handler, "table")
+def test_notify_expired_subscription(mock_table, mock_webpush):
+    mock_table.scan.return_value = {"Items": [_make_item()]}
+    mock_table.delete_item.return_value = {}
+    exc = WebPushException("Gone")
+    resp_mock = MagicMock()
+    resp_mock.status_code = 410
+    exc.response = resp_mock
+    mock_webpush.side_effect = exc
+    result = handler.lambda_handler({}, None)
+    assert result["removed"] == 1
+    assert result["sent"] == 0
+    assert result["failed"] == 0
+    mock_table.delete_item.assert_called_once()
+
+
+@patch.object(handler, "webpush")
+@patch.object(handler, "table")
+def test_notify_empty_subscriptions(mock_table, mock_webpush):
+    mock_table.scan.return_value = {"Items": []}
+    result = handler.lambda_handler({}, None)
+    assert result["sent"] == 0
+    assert result["failed"] == 0
+    assert result["removed"] == 0
+    mock_webpush.assert_not_called()
+
+
+@patch.object(handler, "webpush")
+@patch.object(handler, "table")
+def test_notify_push_failure(mock_table, mock_webpush):
+    mock_table.scan.return_value = {"Items": [_make_item()]}
+    exc = WebPushException("Internal Server Error")
+    resp_mock = MagicMock()
+    resp_mock.status_code = 500
+    exc.response = resp_mock
+    mock_webpush.side_effect = exc
+    result = handler.lambda_handler({}, None)
+    assert result["failed"] == 1
+    assert result["sent"] == 0
+    assert result["removed"] == 0

--- a/lambda/push_subscribe/test_handler.py
+++ b/lambda/push_subscribe/test_handler.py
@@ -1,0 +1,74 @@
+import importlib.util
+import json
+import os
+import sys
+from unittest.mock import patch
+
+os.environ.setdefault("PUSH_SUBSCRIPTIONS_TABLE", "test-subscriptions")
+
+_spec = importlib.util.spec_from_file_location(
+    "push_subscribe_handler",
+    os.path.join(os.path.dirname(__file__), "handler.py"),
+)
+handler = importlib.util.module_from_spec(_spec)
+sys.modules["push_subscribe_handler"] = handler
+_spec.loader.exec_module(handler)
+
+VALID_USER = "12345678-1234-1234-1234-123456789abc"
+VALID_SUBSCRIPTION = {
+    "endpoint": "https://fcm.googleapis.com/fcm/send/dummy-endpoint",
+    "keys": {"p256dh": "key123", "auth": "auth456"},
+}
+
+
+def _event(method="POST", user_id=VALID_USER, body=None):
+    return {
+        "requestContext": {
+            "authorizer": {"jwt": {"claims": {"sub": user_id}}},
+            "http": {"method": method},
+        },
+        "body": json.dumps(body) if body is not None else None,
+    }
+
+
+@patch.object(handler, "table")
+def test_subscribe_success(mock_table):
+    mock_table.put_item.return_value = {}
+    resp = handler.lambda_handler(
+        _event(method="POST", body={"subscription": VALID_SUBSCRIPTION}), None
+    )
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["message"] == "subscribed"
+    mock_table.put_item.assert_called_once()
+
+
+@patch.object(handler, "table")
+def test_unsubscribe_success(mock_table):
+    mock_table.delete_item.return_value = {}
+    resp = handler.lambda_handler(_event(method="DELETE"), None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["message"] == "unsubscribed"
+    mock_table.delete_item.assert_called_once()
+
+
+def test_unauthorized():
+    resp = handler.lambda_handler({}, None)
+    assert resp["statusCode"] == 401
+    body = json.loads(resp["body"])
+    assert "Unauthorized" in body["error"]
+
+
+def test_missing_subscription():
+    resp = handler.lambda_handler(_event(method="POST", body={}), None)
+    assert resp["statusCode"] == 400
+
+
+def test_invalid_subscription_format():
+    # endpoint はあるが keys がない
+    resp = handler.lambda_handler(
+        _event(method="POST", body={"subscription": {"endpoint": "https://example.com"}}),
+        None,
+    )
+    assert resp["statusCode"] == 400

--- a/lambda/save_item_config/test_handler.py
+++ b/lambda/save_item_config/test_handler.py
@@ -96,3 +96,65 @@ def test_save_missing_configs_key(mock_table):
 def test_missing_auth():
     result = handler.lambda_handler({}, None)
     assert result["statusCode"] == 401
+
+
+# --- 追加テストケース（要件名） ---
+
+VALID_USER = "12345678-1234-1234-1234-123456789abc"
+
+
+def _event(user_id=VALID_USER, body=None):
+    return {
+        "requestContext": {"authorizer": {"jwt": {"claims": {"sub": user_id}}}},
+        "body": json.dumps(body) if body is not None else None,
+    }
+
+
+@patch.object(handler, "table")
+def test_save_success(mock_table):
+    mock_table.put_item.return_value = {}
+    configs = [{"item_id": "i1", "label": "体重", "type": "number", "mode": "form"}]
+    resp = handler.lambda_handler(_event(body={"configs": configs}), None)
+    assert resp["statusCode"] == 200
+    assert json.loads(resp["body"])["message"] == "saved"
+
+
+def test_unauthorized():
+    resp = handler.lambda_handler({}, None)
+    assert resp["statusCode"] == 401
+
+
+def test_invalid_json():
+    raw_event = {
+        "requestContext": {"authorizer": {"jwt": {"claims": {"sub": VALID_USER}}}},
+        "body": "this is not json{{{",
+    }
+    resp = handler.lambda_handler(raw_event, None)
+    assert resp["statusCode"] == 400
+
+
+def test_missing_configs():
+    resp = handler.lambda_handler(_event(body={}), None)
+    assert resp["statusCode"] == 400
+
+
+@patch.object(handler, "table")
+def test_invalid_type(mock_table):
+    configs = [{"item_id": "i1", "label": "test", "type": "INVALID", "mode": "form"}]
+    resp = handler.lambda_handler(_event(body={"configs": configs}), None)
+    assert resp["statusCode"] == 400
+
+
+@patch.object(handler, "table")
+def test_invalid_mode(mock_table):
+    configs = [{"item_id": "i1", "label": "test", "type": "checkbox", "mode": "INVALID"}]
+    resp = handler.lambda_handler(_event(body={"configs": configs}), None)
+    assert resp["statusCode"] == 400
+
+
+@patch.object(handler, "table")
+def test_missing_required_fields(mock_table):
+    # item_id なし
+    configs = [{"label": "test", "type": "checkbox", "mode": "form"}]
+    resp = handler.lambda_handler(_event(body={"configs": configs}), None)
+    assert resp["statusCode"] == 400

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,22 @@
+[pytest]
+norecursedirs =
+    lambda/get_env_data/annotated_types
+    lambda/get_env_data/boto3
+    lambda/get_env_data/botocore
+    lambda/get_env_data/certifi
+    lambda/get_env_data/charset_normalizer
+    lambda/get_env_data/idna
+    lambda/get_env_data/jmespath
+    lambda/get_env_data/pydantic
+    lambda/get_env_data/pydantic_core
+    lambda/get_env_data/requests
+    lambda/get_env_data/s3transfer
+    lambda/get_env_data/typing_inspection
+    lambda/get_env_data/urllib3
+    lambda/get_env_data/bin
+    lambda/get_env_data/clients
+    lambda/get_env_data/services
+    .git
+    __pycache__
+    node_modules
+    .venv


### PR DESCRIPTION
## 関連イシュー
Closes #83

## 背景
探索エージェントによるコードベース全体の調査結果を受けて、テスト不足・ドキュメント不足・Rules 不足を一括解消。

---

## 変更内容

### Lambda テスト追加

| ハンドラー | 追加テスト数 | カバー内容 |
|-----------|------------|---------|
| `get_item_config` | 3 | DynamoDB 取得・空レスポンス・認証エラー |
| `save_item_config` | 7 | バリデーション全パターン（type/mode/必須項目） |
| `push_subscribe` | 5 (新規) | POST/DELETE・認証・subscription 形式エラー |
| `push_notify` | 4 (新規) | 送信成功・期限切れ削除・空・失敗 |
| `delete_record` | 1 | タイムアウト（504）ケース |

**合計: 92 tests, 全件 PASSED**

`pytest.ini` を追加して `get_env_data/` バンドルの third-party パスが pytest に収集されないよう設定。

### ドキュメント整備（7 ファイル新規作成）

| ファイル | 行数 | 概要 |
|---------|------|------|
| `docs/API_REFERENCE.md` | 512 | 全 8 エンドポイント仕様（リクエスト/レスポンス/エラー） |
| `docs/DATABASE_SCHEMA.md` | 220 | Iceberg スキーマ・FLAGS ビットマスク・DynamoDB |
| `docs/DEPLOYMENT_GUIDE.md` | 265 | 初回・更新デプロイ手順書（CORS・callback_urls 設定含む） |
| `docs/LAMBDA_DEVELOPMENT.md` | 372 | Lambda 開発・テスト・パッケージング・新規追加手順 |
| `docs/FRONTEND_DEVELOPMENT.md` | 274 | フロントエンド開発・Amplify Auth・useOfflineQueue |
| `docs/DBT_OPERATIONS.md` | 252 | dbt 実行・スキーマ変更・docs 生成 |
| `docs/TROUBLESHOOTING.md` | 292 | よくあるエラー 10 項目と対処法 |

`docs/README.md` に新規ドキュメントへのリンクを追加。

### .claude/rules 追加

- `.claude/rules/dbt/modeling.md`
  - パスフィルター: `data/dbt/**/*.sql`, `data/dbt/**/*.yml`
  - 命名規則（staging/intermediate/marts）
  - Materialization 戦略と incremental 設定
  - スキーマテスト（`_*.yml`）の書き方
  - Macro の使用パターン
  - Athena (S3 Tables) 対応の注意事項

---

## テスト確認

- [x] `pytest lambda/ -v` → **92 passed in 6.68s**
- [x] 新規テスト: 正常系・バリデーションエラー・AWS エラーの 3 パターンをカバー

## レビュー観点

- `push_notify/test_handler.py`: `webpush` のモックが適切か（外部依存を正しくモックしているか）
- `docs/DEPLOYMENT_GUIDE.md`: 初回デプロイ手順が実際のフローと一致しているか
- `docs/API_REFERENCE.md`: エンドポイント URL・メソッドが Terraform の apigw 定義と一致しているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)