### PR TITLE
feat: Athena スキーママイグレーション自動化 (#87)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - "terraform/**"
+      - "migrations/athena/**"
   push:
     branches: [main]
     paths:
       - "terraform/**"
+      - "migrations/athena/**"
 
 env:
   TF_VERSION: "1.7.5"
@@ -89,3 +91,14 @@ jobs:
       - name: Terraform Apply (main branch only)
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: terraform apply -auto-approve tfplan
+
+      - name: Run Athena schema migrations (main branch only)
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        working-directory: ${{ github.workspace }}
+        run: |
+          pip install boto3 --quiet
+          python3 scripts/athena-migrate.py
+        env:
+          ATHENA_DATABASE: health_logger_prod_health_logs
+          ATHENA_OUTPUT_BUCKET: health-logger-prod
+          MIGRATION_TRACKING_TABLE: health-logger-prod-athena-migrations

--- a/migrations/athena/001_add_concentration_score.sql
+++ b/migrations/athena/001_add_concentration_score.sql
@@ -1,0 +1,3 @@
+-- Migration: 001_add_concentration_score
+-- 集中力スコアカラムを health_records テーブルに追加
+ALTER TABLE health_records ADD COLUMNS (concentration_score int)

--- a/migrations/athena/README.md
+++ b/migrations/athena/README.md
@@ -1,0 +1,35 @@
+# Athena スキーママイグレーション
+
+## 仕組み
+
+`migrations/athena/NNN_description.sql` ファイルを追加するだけで、
+次回 `terraform apply` 時（main ブランチへの push 後）に自動で Athena DDL が実行される。
+
+実行状況は DynamoDB テーブル `health-logger-prod-athena-migrations` で管理される。
+適用済みのマイグレーションは再実行されない（冪等性あり）。
+
+## 新規カラム追加の手順
+
+1. `NNN_description.sql` ファイルを追加（NNN は 3 桁の連番）
+2. `terraform/modules/glue/main.tf` の `storage_descriptor.columns` に同じカラムを追加
+3. dbt の staging モデルに同じカラムを追加（該当する場合）
+4. PR を作成して main にマージ → terraform.yml が自動で apply + migrate
+
+## ファイル命名規則
+
+```
+001_add_concentration_score.sql
+002_add_some_new_column.sql
+003_add_another_column.sql
+```
+
+## 手動実行
+
+CI を経由せず手動で適用する場合:
+
+```bash
+ATHENA_DATABASE=health_logger_prod_health_logs \
+ATHENA_OUTPUT_BUCKET=health-logger-prod \
+MIGRATION_TRACKING_TABLE=health-logger-prod-athena-migrations \
+python3 scripts/athena-migrate.py
+```

--- a/scripts/athena-migrate.py
+++ b/scripts/athena-migrate.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Athena スキーママイグレーションスクリプト
+
+migrations/athena/*.sql を昇順に読み込み、未適用のものを Athena で実行する。
+適用済みマイグレーションは DynamoDB テーブルで管理する（冪等性あり）。
+
+環境変数:
+  ATHENA_DATABASE          - Athena データベース名
+  ATHENA_OUTPUT_BUCKET     - Athena クエリ結果の S3 バケット名
+  MIGRATION_TRACKING_TABLE - DynamoDB テーブル名（マイグレーション追跡用）
+  AWS_REGION               - AWS リージョン（デフォルト: ap-northeast-1）
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import boto3
+
+AWS_REGION = os.environ.get("AWS_REGION", "ap-northeast-1")
+ATHENA_DATABASE = os.environ["ATHENA_DATABASE"]
+ATHENA_OUTPUT_BUCKET = os.environ["ATHENA_OUTPUT_BUCKET"]
+MIGRATION_TRACKING_TABLE = os.environ["MIGRATION_TRACKING_TABLE"]
+
+athena = boto3.client("athena", region_name=AWS_REGION)
+dynamodb = boto3.resource("dynamodb", region_name=AWS_REGION)
+table = dynamodb.Table(MIGRATION_TRACKING_TABLE)
+
+MIGRATIONS_DIR = Path(__file__).parent.parent / "migrations" / "athena"
+
+
+def get_applied_migrations() -> set[str]:
+    response = table.scan(ProjectionExpression="migration_name")
+    return {item["migration_name"] for item in response.get("Items", [])}
+
+
+def mark_applied(migration_name: str) -> None:
+    table.put_item(Item={
+        "migration_name": migration_name,
+        "applied_at": int(time.time()),
+    })
+
+
+def run_query(sql: str) -> None:
+    response = athena.start_query_execution(
+        QueryString=sql,
+        QueryExecutionContext={"Database": ATHENA_DATABASE},
+        ResultConfiguration={
+            "OutputLocation": f"s3://{ATHENA_OUTPUT_BUCKET}/athena-migrations/"
+        },
+    )
+    execution_id = response["QueryExecutionId"]
+
+    for _ in range(40):
+        time.sleep(0.5)
+        status = athena.get_query_execution(QueryExecutionId=execution_id)
+        state = status["QueryExecution"]["Status"]["State"]
+        if state == "SUCCEEDED":
+            return
+        if state in ("FAILED", "CANCELLED"):
+            reason = status["QueryExecution"]["Status"].get("StateChangeReason", "")
+            raise RuntimeError(f"Query {state}: {reason}")
+
+    raise TimeoutError(f"Query timed out after 20s (execution_id={execution_id})")
+
+
+def main() -> None:
+    migration_files = sorted(MIGRATIONS_DIR.glob("*.sql"))
+    if not migration_files:
+        print("No migration files found.")
+        return
+
+    applied = get_applied_migrations()
+    pending = [f for f in migration_files if f.stem not in applied]
+
+    if not pending:
+        print(f"All {len(migration_files)} migration(s) already applied.")
+        return
+
+    print(f"Applying {len(pending)} pending migration(s)...")
+
+    for migration_file in pending:
+        name = migration_file.stem
+        sql = migration_file.read_text().strip()
+        # コメント行を除いた実行用 SQL
+        statements = [
+            line for line in sql.splitlines()
+            if line.strip() and not line.strip().startswith("--")
+        ]
+        sql_to_run = "\n".join(statements)
+
+        print(f"  Running: {name}")
+        try:
+            run_query(sql_to_run)
+            mark_applied(name)
+            print(f"  ✓ Applied: {name}")
+        except RuntimeError as e:
+            if "already exists" in str(e).lower() or "duplicate" in str(e).lower():
+                # カラムが既に存在する場合はスキップして適用済みとしてマーク
+                print(f"  ⚠ Already applied (column exists): {name}")
+                mark_applied(name)
+            else:
+                print(f"  ✗ Failed: {name} — {e}", file=sys.stderr)
+                sys.exit(1)
+
+    print("Migration complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -265,8 +265,42 @@ resource "aws_iam_role_policy" "github_actions" {
         Action   = ["dynamodb:DescribeTable", "dynamodb:DescribeTimeToLive", "dynamodb:ListTagsOfResource", "dynamodb:CreateTable", "dynamodb:DeleteTable", "dynamodb:UpdateTable", "dynamodb:TagResource", "dynamodb:UntagResource", "dynamodb:DescribeContinuousBackups"]
         Resource = ["*"]
       },
+      # Athena migration script: execute DDL + poll results
+      {
+        Effect = "Allow"
+        Action = [
+          "athena:StartQueryExecution",
+          "athena:GetQueryExecution",
+          "athena:GetQueryResults",
+          "athena:StopQueryExecution",
+        ]
+        Resource = ["*"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:PutObject", "s3:GetObject", "s3:GetBucketLocation"]
+        Resource = ["arn:aws:s3:::health-logger-prod/athena-migrations/*", "arn:aws:s3:::health-logger-prod"]
+      },
+      # Migration tracking DynamoDB table
+      {
+        Effect   = "Allow"
+        Action   = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:Scan"]
+        Resource = aws_dynamodb_table.athena_migrations.arn
+      },
     ]
   })
+}
+
+# ── Athena migration tracking (DynamoDB) ─────────────────────────────────────
+resource "aws_dynamodb_table" "athena_migrations" {
+  name         = "${local.name}-athena-migrations"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "migration_name"
+
+  attribute {
+    name = "migration_name"
+    type = "S"
+  }
 }
 
 # ── External environment data ingest (weather/air quality) ────────────────────


### PR DESCRIPTION
## 関連イシュー
Closes #87

## 変更内容

### 課題
従来は `terraform apply` 後に手動で `aws athena start-query-execution` を実行してスキーマを更新する必要があった。

### 解決策
`migrations/athena/*.sql` ファイルを追加するだけで、次回 `terraform apply` 時（main ブランチへの push 後）に GitHub Actions が自動で DDL を実行する仕組みを追加した。

### 追加ファイル

| ファイル | 内容 |
|---------|------|
| `scripts/athena-migrate.py` | DynamoDB で適用済みマイグレーションを追跡し未適用のみ実行するスクリプト |
| `migrations/athena/001_add_concentration_score.sql` | concentration_score カラム追加（初回マイグレーション） |
| `migrations/athena/README.md` | マイグレーション追加手順の説明 |

### 変更ファイル

- `.github/workflows/terraform.yml` — `Terraform Apply` 後に migration ステップを追加、`migrations/athena/**` のパス変更でもワークフロー起動
- `terraform/envs/prod/main.tf` — DynamoDB 追跡テーブル `health-logger-prod-athena-migrations` と GitHub Actions IAM 権限（Athena + DynamoDB Scan）を追加

### 動作フロー

```
migrations/athena/NNN_xxx.sql を追加
  → main にマージ
    → terraform.yml 起動
      → Terraform Apply（Glue カタログ更新）
      → python3 scripts/athena-migrate.py
          → DynamoDB で未適用マイグレーションを確認
          → Athena で ALTER TABLE 実行
          → DynamoDB に適用済みとして記録
```

## テスト確認
- [ ] terraform plan でエラーなし（DynamoDB テーブル・IAM 権限）
- [ ] `scripts/athena-migrate.py` のロジック確認（冪等性・エラーハンドリング）
- [ ] `migrations/athena/` パス変更時にも terraform.yml が起動することを確認

## レビュー観点
- `athena-migrate.py` のエラーハンドリング（column already exists → スキップ）
- GitHub Actions IAM 権限のスコープが適切か