### PR TITLE
fix: 登録しましたトーストが表示されない (#92)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import AuthGuard from './components/AuthGuard'
 import DashboardPage from './components/DashboardPage'
 import HealthForm from './components/HealthForm'
+import type { ToastVariant } from './components/HealthForm'
 import ItemConfigScreen from './components/ItemConfigScreen'
 import RecordHistory from './components/RecordHistory'
 import { getLatest } from './api'
@@ -21,6 +22,14 @@ function AppContent() {
   const [showSettings, setShowSettings] = useState(false)
   const [page, setPage] = useState(0)
   const [records, setRecords] = useState<LatestRecord[]>([])
+  const [toast, setToast] = useState<{ show: boolean; message: string; variant: ToastVariant }>({ show: false, message: '', variant: 'success' })
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const showToast = (message: string, variant: ToastVariant) => {
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
+    setToast({ show: true, message, variant })
+    toastTimerRef.current = setTimeout(() => setToast((t) => ({ ...t, show: false })), 3000)
+  }
 
   const touchStartX = useRef(0)
   const handleTouchStart = (e: React.TouchEvent) => {
@@ -60,6 +69,25 @@ function AppContent() {
 
   return (
     <div style={{ height: '100dvh', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      {/* Toast (rendered outside transform container to avoid position:fixed containment) */}
+      {toast.show && (
+        <div
+          className={`alert alert-${toast.variant} mb-0`}
+          role="alert"
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            zIndex: 2000,
+            borderRadius: 0,
+            textAlign: 'center',
+          }}
+        >
+          {toast.message}
+        </div>
+      )}
+
       {/* Navbar */}
       <nav className="navbar navbar-expand navbar-light bg-light border-bottom" style={{ flexShrink: 0 }}>
         <div className="container">
@@ -134,6 +162,7 @@ function AppContent() {
               eventItems={eventItems}
               statusItems={statusItems}
               latestDailyRecord={latestDailyRecord}
+              onToast={showToast}
             />
           </div>
 

--- a/frontend/src/components/HealthForm.tsx
+++ b/frontend/src/components/HealthForm.tsx
@@ -43,17 +43,17 @@ function datetimeLocalToISO(value: string): string {
   return new Date(value).toISOString()
 }
 
-type ToastVariant = 'success' | 'danger' | 'warning'
-interface ToastState { show: boolean; message: string; variant: ToastVariant }
+export type ToastVariant = 'success' | 'danger' | 'warning'
 
 interface Props {
   formItems:    ItemConfig[]
   eventItems:   ItemConfig[]
   statusItems:  ItemConfig[]
   latestDailyRecord?: LatestRecord
+  onToast: (message: string, variant: ToastVariant) => void
 }
 
-export default function HealthForm({ formItems, eventItems, statusItems, latestDailyRecord }: Props) {
+export default function HealthForm({ formItems, eventItems, statusItems, latestDailyRecord, onToast }: Props) {
   const { token } = useAuth()
   const { enqueue, flush } = useOfflineQueue(API_ENDPOINT)
 
@@ -115,13 +115,6 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
     } catch {}
   }, [activeStatuses])
 
-  const [toast, setToast] = useState<ToastState>({ show: false, message: '', variant: 'success' })
-
-  const showToast = (message: string, variant: ToastVariant) => {
-    setToast({ show: true, message, variant })
-    setTimeout(() => setToast((t) => ({ ...t, show: false })), 3000)
-  }
-
   const setCustomValue = (itemId: string, value: number | boolean | string) =>
     setCustomValues((prev) => ({ ...prev, [itemId]: value }))
 
@@ -143,9 +136,9 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
     } catch {
       if (!navigator.onLine) {
         await enqueue(record, token!).catch(() => {})
-        showToast('オフラインのためキューに保存しました', 'warning')
+        onToast('オフラインのためキューに保存しました', 'warning')
       } else {
-        showToast('送信に失敗しました', 'danger')
+        onToast('送信に失敗しました', 'danger')
       }
       return false
     }
@@ -171,7 +164,7 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
     }
     const ok = await submitRecord(record)
     if (ok) {
-      showToast('記録しました！', 'success')
+      onToast('記録しました！', 'success')
       setNote('')
       setCustomValues({})
       flush(token).catch(() => {})
@@ -197,7 +190,7 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
     }
     const ok = await submitRecord(record)
     if (ok) {
-      showToast(`${item.label} を記録しました`, 'success')
+      onToast(`${item.label} を記録しました`, 'success')
       flush(token).catch(() => {})
     }
     setEventSending((s) => ({ ...s, [item.item_id]: false }))
@@ -220,7 +213,7 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
     }
     const ok = await submitRecord(record)
     if (ok) {
-      showToast(`${label} を${nextActive ? 'ON' : 'OFF'}にしました`, 'success')
+      onToast(`${label} を${nextActive ? 'ON' : 'OFF'}にしました`, 'success')
       flush(token).catch(() => {})
     } else {
       // 失敗時は状態を元に戻す
@@ -255,7 +248,7 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
     }
     const ok = await submitRecord(record)
     if (ok) {
-      showToast(`${item.label} を記録しました`, 'success')
+      onToast(`${item.label} を記録しました`, 'success')
       setEventInputs((prev) => ({ ...prev, [item.item_id]: '' }))
       flush(token).catch(() => {})
     }
@@ -266,24 +259,6 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
 
   return (
     <div className="container py-4" style={{ maxWidth: '540px' }}>
-      {toast.show && (
-        <div
-          className={`alert alert-${toast.variant} mb-0`}
-          role="alert"
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            zIndex: 2000,
-            borderRadius: 0,
-            textAlign: 'center',
-          }}
-        >
-          {toast.message}
-        </div>
-      )}
-
       {/* ── 記録日時ピッカー（全体共通）──────────────────────── */}
       <div
         className="mb-4 p-3 rounded"


### PR DESCRIPTION
## 関連イシュー
Closes #92

## 変更内容
- `HealthForm` のトースト state を `App.tsx` に移動
- `HealthForm` に `onToast: (message, variant) => void` prop を追加
- トーストを `transform: translateX()` コンテナ外のルートレベルでレンダリング

## 原因
CSS 仕様: `transform` プロパティが適用された要素は `position: fixed` 子要素の含有ブロック（containing block）になる。
スワイプコンテナに `transform: translateX(-${page * 33.333}%)` が適用されているため、
その内部の `HealthForm` で `position: fixed` なトーストを使うとビューポート基準にならずクリップされていた。

## テスト確認
- [x] `npx tsc --noEmit` → エラーなし
- [x] `npm test` → 19 tests passed

## レビュー観点
- `ToastVariant` 型を `HealthForm.tsx` から export し `App.tsx` でインポート
- `toastTimerRef` で連続送信時のタイマー重複をクリア