### PR TITLE
feat: Material Design準拠のUI/UX改善 (#96)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-amplify/auth": "^6.0.0",
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
+        "@mui/material": "^7.3.9",
         "@types/recharts": "^1.8.29",
         "aws-amplify": "^6.0.0",
         "react": "^18.3.1",
@@ -1688,7 +1691,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -1744,7 +1746,6 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -1778,7 +1779,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1788,7 +1788,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -1830,7 +1829,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1840,7 +1838,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1874,7 +1871,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
       "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -1918,11 +1914,19 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -1937,7 +1941,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -1956,7 +1959,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1965,6 +1967,158 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -2361,7 +2515,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2383,7 +2536,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2393,18 +2545,223 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.9.tgz",
+      "integrity": "sha512-MOkOCTfbMJwLshlBCKJ59V2F/uaLYfmKnN76kksj6jlGUVdI25A9Hzs08m+zjBRdLv+sK7Rqdsefe8X7h/6PCw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.9.tgz",
+      "integrity": "sha512-I8yO3t4T0y7bvDiR1qhIN6iBWZOTBfVOnmLlM7K6h3dx5YX2a7rnkuXzc2UkZaqhxY9NgTnEbdPlokR1RxCNRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/core-downloads-tracker": "^7.3.9",
+        "@mui/system": "^7.3.9",
+        "@mui/types": "^7.4.12",
+        "@mui/utils": "^7.3.9",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.3",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^7.3.9",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.9.tgz",
+      "integrity": "sha512-ErIyRQvsiQEq7Yvcvfw9UDHngaqjMy9P3JDPnRAaKG5qhpl2C4tX/W1S4zJvpu+feihmZJStjIyvnv6KDbIrlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/utils": "^7.3.9",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.9.tgz",
+      "integrity": "sha512-JqujWt5bX4okjUPGpVof/7pvgClqh7HvIbsIBIOOlCh2u3wG/Bwp4+E1bc1dXSwkrkp9WUAoNdI5HEC+5HKvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.9.tgz",
+      "integrity": "sha512-aL1q9am8XpRrSabv9qWf5RHhJICJql34wnrc1nz0MuOglPRYF/liN+c8VqZdTvUn9qg+ZjRVbKf4sJVFfIDtmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/private-theming": "^7.3.9",
+        "@mui/styled-engine": "^7.3.9",
+        "@mui/types": "^7.4.12",
+        "@mui/utils": "^7.3.9",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
+      "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.9.tgz",
+      "integrity": "sha512-U6SdZaGbfb65fqTsH3V5oJdFj9uYwyLE2WVuNvmbggTSDBb8QHrFsqY8BN3taK9t3yJ8/BPHD/kNvLNyjwM7Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/types": "^7.4.12",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@playwright/test": {
@@ -2421,6 +2778,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -4368,6 +4735,12 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -4392,6 +4765,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/recharts": {
@@ -4576,6 +4958,21 @@
         "tslib": "^2.5.0"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4670,6 +5067,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001775",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001775.tgz",
@@ -4733,6 +5139,22 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -4877,7 +5299,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4907,6 +5328,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -4926,6 +5357,15 @@
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -4993,6 +5433,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -5050,6 +5502,12 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5063,6 +5521,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gensync": {
@@ -5083,6 +5550,33 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/idb": {
       "version": "5.0.6",
@@ -5120,6 +5614,22 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -5127,6 +5637,27 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/isarray": {
@@ -5154,7 +5685,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -5162,6 +5692,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -5175,6 +5711,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
     },
     "node_modules/lodash": {
       "version": "4.17.23",
@@ -5225,7 +5767,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5254,6 +5795,60 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -5275,7 +5870,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/playwright": {
@@ -5354,6 +5948,23 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -5383,8 +5994,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -5417,6 +6027,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/recharts": {
@@ -5479,6 +6105,35 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -5560,6 +6215,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5595,6 +6259,24 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -5931,6 +6613,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,9 @@
   },
   "dependencies": {
     "@aws-amplify/auth": "^6.0.0",
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/material": "^7.3.9",
     "@types/recharts": "^1.8.29",
     "aws-amplify": "^6.0.0",
     "react": "^18.3.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
+import BottomNavigation from '@mui/material/BottomNavigation'
+import BottomNavigationAction from '@mui/material/BottomNavigationAction'
+import Fab from '@mui/material/Fab'
 import AuthGuard from './components/AuthGuard'
 import DashboardPage from './components/DashboardPage'
 import HealthForm from './components/HealthForm'
@@ -117,29 +120,6 @@ function AppContent() {
         </div>
       </nav>
 
-      {/* Tab bar */}
-      <div style={{ display: 'flex', borderBottom: '1px solid #dee2e6', backgroundColor: '#fff', flexShrink: 0 }}>
-        {['📝 記録', '📋 履歴', '📊 分析'].map((label, i) => (
-          <button
-            key={i}
-            onClick={() => setPage(i)}
-            style={{
-              flex: 1,
-              padding: '10px',
-              border: 'none',
-              borderBottom: page === i ? '2px solid #198754' : '2px solid transparent',
-              backgroundColor: 'transparent',
-              fontWeight: page === i ? 600 : 400,
-              color: page === i ? '#198754' : '#6c757d',
-              fontSize: '0.85rem',
-              cursor: 'pointer',
-            }}
-          >
-            {label}
-          </button>
-        ))}
-      </div>
-
       {/* Swipeable pages */}
       <div
         style={{ flex: 1, overflow: 'hidden', position: 'relative' }}
@@ -156,7 +136,7 @@ function AppContent() {
           }}
         >
           {/* Page 0: 記録フォーム */}
-          <div style={{ width: '33.333%', height: '100%', overflowY: 'auto' }}>
+          <div style={{ width: '33.333%', height: '100%', overflowY: 'auto', paddingBottom: '72px' }}>
             <HealthForm
               formItems={formItems}
               eventItems={eventItems}
@@ -167,18 +147,77 @@ function AppContent() {
           </div>
 
           {/* Page 1: 履歴 */}
-          <div style={{ width: '33.333%', height: '100%', overflowY: 'auto' }}>
+          <div style={{ width: '33.333%', height: '100%', overflowY: 'auto', paddingBottom: '72px' }}>
             <div className="container py-3" style={{ maxWidth: '540px' }}>
               <RecordHistory records={records} onDeleted={handleRecordDeleted} />
             </div>
           </div>
 
           {/* Page 2: 分析 */}
-          <div style={{ width: '33.333%', height: '100%', overflowY: 'auto' }}>
+          <div style={{ width: '33.333%', height: '100%', overflowY: 'auto', paddingBottom: '72px' }}>
             <DashboardPage onBack={() => setPage(0)} />
           </div>
         </div>
       </div>
+
+      {/* FAB: 履歴・分析ページにいるときのみ表示 */}
+      {page !== 0 && (
+        <Fab
+          color="success"
+          aria-label="体調を記録する"
+          onClick={() => setPage(0)}
+          sx={{
+            position: 'fixed',
+            bottom: 80,
+            right: 16,
+            zIndex: 1200,
+            bgcolor: '#198754',
+            '&:hover': { bgcolor: '#146c43' },
+          }}
+        >
+          <span style={{ fontSize: '1.4rem', lineHeight: 1 }}>📝</span>
+        </Fab>
+      )}
+
+      {/* Bottom Navigation */}
+      <BottomNavigation
+        value={page}
+        onChange={(_, newValue: number) => setPage(newValue)}
+        showLabels
+        sx={{
+          flexShrink: 0,
+          borderTop: '1px solid #dee2e6',
+          bgcolor: '#fff',
+          height: '64px',
+          '& .MuiBottomNavigationAction-root': {
+            color: '#6c757d',
+            minWidth: 0,
+            fontSize: '0.75rem',
+          },
+          '& .MuiBottomNavigationAction-root.Mui-selected': {
+            color: '#198754',
+          },
+          '& .MuiBottomNavigationAction-label': {
+            fontSize: '0.75rem',
+          },
+          '& .MuiBottomNavigationAction-label.Mui-selected': {
+            fontSize: '0.75rem',
+          },
+        }}
+      >
+        <BottomNavigationAction
+          label="記録"
+          icon={<span style={{ fontSize: '1.4rem', lineHeight: 1 }}>📝</span>}
+        />
+        <BottomNavigationAction
+          label="履歴"
+          icon={<span style={{ fontSize: '1.4rem', lineHeight: 1 }}>📋</span>}
+        />
+        <BottomNavigationAction
+          label="分析"
+          icon={<span style={{ fontSize: '1.4rem', lineHeight: 1 }}>📊</span>}
+        />
+      </BottomNavigation>
 
       {/* Settings modal */}
       {showSettings && (

--- a/frontend/src/components/HealthForm.tsx
+++ b/frontend/src/components/HealthForm.tsx
@@ -1,4 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import Slider from '@mui/material/Slider'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
 import { createRecord } from '../api'
 import { useAuth } from '../hooks/useAuth'
 import { useOfflineQueue } from '../hooks/useOfflineQueue'
@@ -20,12 +25,12 @@ const STATUS_ITEMS = [
   { item_id: 'working',     label: '勤務中', icon: '💼' },
 ] as const
 
-/** スライダー各項目の accent-color */
+/** スライダー各項目の色 */
 const SLIDER_COLORS = {
-  fatigue:       '#dc3545', // 赤: 疲労が高い = 注意
-  mood:          '#fd7e14', // オレンジ: 気分
-  motivation:    '#198754', // 緑: やる気
-  concentration: '#0d6efd', // 青: 集中力
+  fatigue:       '#dc3545',
+  mood:          '#fd7e14',
+  motivation:    '#198754',
+  concentration: '#0d6efd',
 } as const
 
 /** Date → datetime-local input の値形式 "YYYY-MM-DDTHH:MM" (ローカル時刻) */
@@ -39,7 +44,6 @@ function toDatetimeLocal(date: Date): string {
 
 /** datetime-local の値 "YYYY-MM-DDTHH:MM" → ISO 8601 文字列 (UTC) */
 function datetimeLocalToISO(value: string): string {
-  // new Date("YYYY-MM-DDTHH:MM") はローカル時刻として解釈される
   return new Date(value).toISOString()
 }
 
@@ -57,7 +61,6 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
   const { token } = useAuth()
   const { enqueue, flush } = useOfflineQueue(API_ENDPOINT)
 
-  // 前回値を初期値として設定
   const prevFatigue    = useMemo(() => {
     const v = parseFloat(latestDailyRecord?.fatigue_score ?? '')
     return isNaN(v) ? 50 : v
@@ -75,17 +78,14 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
     return isNaN(v) ? 50 : v
   }, [latestDailyRecord])
 
-  // 記録日時（フォーム全体で共通。デフォルト = 現在時刻）
   const [recordedAt, setRecordedAt] = useState(() => toDatetimeLocal(new Date()))
   const isNowSelected = useMemo(() => {
-    // 現在時刻から1分以内なら「現在」とみなす
     const diff = Math.abs(new Date(recordedAt).getTime() - Date.now())
     return diff < 60 * 1000
   }, [recordedAt])
 
   const resetToNow = () => setRecordedAt(toDatetimeLocal(new Date()))
 
-  // Daily form state（前回値で初期化）
   const [fatigue, setFatigue]             = useState(prevFatigue)
   const [mood, setMood]                   = useState(prevMood)
   const [motivation, setMotivation]       = useState(prevMotivation)
@@ -94,12 +94,9 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
   const [customValues, setCustomValues] = useState<Record<string, number | boolean | string>>({})
   const [submitting, setSubmitting]   = useState(false)
 
-  // Quick event state
   const [eventInputs, setEventInputs] = useState<Record<string, string>>({})
   const [eventSending, setEventSending] = useState<Record<string, boolean>>({})
 
-  // Status toggle state: item_id → true(ON) / false(OFF)
-  // localStorage で永続化し、リロード後も復元する
   const [activeStatuses, setActiveStatuses] = useState<Record<string, boolean>>(() => {
     try {
       const stored = localStorage.getItem('health_logger_active_statuses')
@@ -126,7 +123,6 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
       value:   customValues[item.item_id] ?? (item.type === 'checkbox' ? false : item.type === 'text' ? '' : item.min ?? 0),
     }))
 
-  /** recordedAt の値を ISO 文字列に変換（共通） */
   const getRecordedAtISO = () => datetimeLocalToISO(recordedAt)
 
   const submitRecord = async (record: HealthRecordInput) => {
@@ -156,7 +152,7 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
       concentration_score:  concentration,
       flags:                0,
       note:             note.slice(0, 280),
-      recorded_at:      getRecordedAtISO(),   // ← 選択日時を使用
+      recorded_at:      getRecordedAtISO(),
       timezone:         Intl.DateTimeFormat().resolvedOptions().timeZone,
       device_id:        navigator.userAgent.slice(0, 100),
       app_version:      '1.0.0',
@@ -182,7 +178,7 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
       record_type:   'event',
       flags:         0,
       note:          '',
-      recorded_at:   getRecordedAtISO(),   // ← 選択日時を使用
+      recorded_at:   getRecordedAtISO(),
       timezone:      Intl.DateTimeFormat().resolvedOptions().timeZone,
       device_id:     navigator.userAgent.slice(0, 100),
       app_version:   '1.0.0',
@@ -216,7 +212,6 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
       onToast(`${label} を${nextActive ? 'ON' : 'OFF'}にしました`, 'success')
       flush(token).catch(() => {})
     } else {
-      // 失敗時は状態を元に戻す
       setActiveStatuses((s) => ({ ...s, [itemId]: !nextActive }))
     }
     setEventSending((s) => ({ ...s, [itemId]: false }))
@@ -240,7 +235,7 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
       record_type:   recordType,
       flags:         0,
       note:          '',
-      recorded_at:   getRecordedAtISO(),   // ← 選択日時を使用
+      recorded_at:   getRecordedAtISO(),
       timezone:      Intl.DateTimeFormat().resolvedOptions().timeZone,
       device_id:     navigator.userAgent.slice(0, 100),
       app_version:   '1.0.0',
@@ -258,10 +253,10 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
   const hasPrev = latestDailyRecord != null
 
   return (
-    <div className="container py-4" style={{ maxWidth: '540px' }}>
-      {/* ── 記録日時ピッカー（全体共通）──────────────────────── */}
+    <div className="container py-3" style={{ maxWidth: '540px' }}>
+      {/* ── 記録日時ピッカー ──────────────────────── */}
       <div
-        className="mb-4 p-3 rounded"
+        className="mb-3 p-3 rounded"
         style={{
           backgroundColor: isNowSelected ? '#f8f9fa' : '#fff3cd',
           border: `1px solid ${isNowSelected ? '#dee2e6' : '#ffc107'}`,
@@ -276,7 +271,7 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
             className="form-control form-control-sm"
             style={{ maxWidth: '220px' }}
             value={recordedAt}
-            max={toDatetimeLocal(new Date())}   // 未来日時は選択不可
+            max={toDatetimeLocal(new Date())}
             onChange={(e) => setRecordedAt(e.target.value)}
           />
           {!isNowSelected && (
@@ -303,86 +298,63 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
       </div>
 
       {/* ── Status (ongoing conditions) ───────────────────────── */}
-      <div className="mb-4">
-        <h2 className="h6 text-muted mb-2">ステータス</h2>
-        <div className="d-flex flex-wrap gap-2">
-          {[...STATUS_ITEMS, ...statusItems].map((item) => {
-            const isOn = activeStatuses[item.item_id] ?? false
-            return (
-              <button
-                key={item.item_id}
-                type="button"
-                className={isOn ? 'btn btn-warning' : 'btn btn-outline-warning'}
-                onClick={() => toggleStatus(item.item_id, item.label)}
-                disabled={eventSending[item.item_id]}
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  gap: '2px',
-                  padding: '8px 12px',
-                  minWidth: '64px',
-                }}
-              >
-                {eventSending[item.item_id] ? (
-                  <span className="spinner-border spinner-border-sm" role="status" />
-                ) : (
-                  <>
-                    <span style={{ fontSize: '1.4rem', lineHeight: 1 }}>
-                      {'icon' in item ? item.icon : (item.icon ?? '●')}
-                    </span>
-                    <span style={{ fontSize: '0.7rem' }}>{item.label}</span>
-                    {isOn && (
-                      <span style={{ fontSize: '0.6rem', opacity: 0.8 }}>ON</span>
-                    )}
-                  </>
-                )}
-              </button>
-            )
-          })}
-        </div>
-      </div>
+      <Card variant="outlined" sx={{ mb: 2, borderRadius: 2 }}>
+        <CardContent sx={{ pb: '12px !important', pt: 1.5, px: 2 }}>
+          <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1.5, fontWeight: 600 }}>
+            ステータス
+          </Typography>
+          <div className="d-flex flex-wrap gap-2">
+            {[...STATUS_ITEMS, ...statusItems].map((item) => {
+              const isOn = activeStatuses[item.item_id] ?? false
+              return (
+                <button
+                  key={item.item_id}
+                  type="button"
+                  className={isOn ? 'btn btn-warning' : 'btn btn-outline-warning'}
+                  onClick={() => toggleStatus(item.item_id, item.label)}
+                  disabled={eventSending[item.item_id]}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: '2px',
+                    padding: '8px 12px',
+                    minWidth: '64px',
+                  }}
+                >
+                  {eventSending[item.item_id] ? (
+                    <span className="spinner-border spinner-border-sm" role="status" />
+                  ) : (
+                    <>
+                      <span style={{ fontSize: '1.4rem', lineHeight: 1 }}>
+                        {'icon' in item ? item.icon : (item.icon ?? '●')}
+                      </span>
+                      <span style={{ fontSize: '0.7rem' }}>{item.label}</span>
+                      {isOn && (
+                        <span style={{ fontSize: '0.6rem', opacity: 0.8 }}>ON</span>
+                      )}
+                    </>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        </CardContent>
+      </Card>
 
       {/* ── Quick Events (flags + custom event items) ──────────── */}
-      <div className="mb-4">
-        <h2 className="h6 text-muted mb-2">クイックイベント</h2>
-        <div className="d-flex flex-wrap gap-2">
-          {FLAG_ITEMS.map((item) => (
-            <button
-              key={item.item_id}
-              type="button"
-              className="btn btn-outline-secondary"
-              onClick={() => sendFlagEvent(item)}
-              disabled={eventSending[item.item_id]}
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                gap: '2px',
-                padding: '8px 12px',
-                minWidth: '64px',
-              }}
-            >
-              {eventSending[item.item_id] ? (
-                <span className="spinner-border spinner-border-sm" role="status" />
-              ) : (
-                <>
-                  <span style={{ fontSize: '1.4rem', lineHeight: 1 }}>{item.icon}</span>
-                  <span style={{ fontSize: '0.7rem' }}>{item.label}</span>
-                </>
-              )}
-            </button>
-          ))}
-
-          {/* カスタムイベント: checkbox は同じボタンスタイル */}
-          {eventItems
-            .filter((item) => item.type === 'checkbox')
-            .map((item) => (
+      <Card variant="outlined" sx={{ mb: 2, borderRadius: 2 }}>
+        <CardContent sx={{ pb: '12px !important', pt: 1.5, px: 2 }}>
+          <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1.5, fontWeight: 600 }}>
+            クイックイベント
+          </Typography>
+          <div className="d-flex flex-wrap gap-2">
+            {FLAG_ITEMS.map((item) => (
               <button
                 key={item.item_id}
                 type="button"
                 className="btn btn-outline-secondary"
-                onClick={() => handleQuickEvent(item)}
+                onClick={() => sendFlagEvent(item)}
                 disabled={eventSending[item.item_id]}
                 style={{
                   display: 'flex',
@@ -397,213 +369,250 @@ export default function HealthForm({ formItems, eventItems, statusItems, latestD
                   <span className="spinner-border spinner-border-sm" role="status" />
                 ) : (
                   <>
-                    <span style={{ fontSize: '1.4rem', lineHeight: 1 }}>{item.icon ?? '✓'}</span>
+                    <span style={{ fontSize: '1.4rem', lineHeight: 1 }}>{item.icon}</span>
                     <span style={{ fontSize: '0.7rem' }}>{item.label}</span>
                   </>
                 )}
               </button>
             ))}
 
-          {/* カスタムイベント: number/slider/text はコンパクトカード */}
-          {eventItems
-            .filter((item) => item.type !== 'checkbox')
-            .map((item) => (
-              <div
-                key={item.item_id}
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: '4px',
-                  padding: '6px 10px',
-                  border: '1px solid #dee2e6',
-                  borderRadius: '6px',
-                  minWidth: '100px',
-                  maxWidth: '140px',
-                  backgroundColor: '#f8f9fa',
-                }}
-              >
-                <span style={{ fontSize: '0.72rem', color: '#6c757d', fontWeight: 500 }}>
-                  {item.icon ? `${item.icon} ` : ''}{item.label}
-                  {item.unit ? ` (${item.unit})` : ''}
-                </span>
-                <input
-                  type={item.type === 'text' ? 'text' : 'number'}
-                  className="form-control form-control-sm"
-                  placeholder={item.unit ?? '値'}
-                  value={eventInputs[item.item_id] ?? ''}
-                  onChange={(e) =>
-                    setEventInputs((prev) => ({ ...prev, [item.item_id]: e.target.value }))
-                  }
-                  style={{ fontSize: '0.8rem', padding: '2px 6px' }}
-                />
+            {eventItems
+              .filter((item) => item.type === 'checkbox')
+              .map((item) => (
                 <button
-                  className="btn btn-outline-success btn-sm"
+                  key={item.item_id}
+                  type="button"
+                  className="btn btn-outline-secondary"
                   onClick={() => handleQuickEvent(item)}
                   disabled={eventSending[item.item_id]}
-                  style={{ fontSize: '0.72rem', padding: '2px 6px' }}
-                >
-                  {eventSending[item.item_id] ? '…' : '記録'}
-                </button>
-              </div>
-            ))}
-        </div>
-      </div>
-
-      {/* ── Daily Form ────────────────────────────────────────── */}
-      <h1 className="h4 mb-4 text-success">体調記録</h1>
-      <form onSubmit={handleSubmit}>
-        {/* Sliders */}
-        {(
-          [
-            { label: '疲労感', value: fatigue,       setter: setFatigue,       colorKey: 'fatigue'       as const, prev: prevFatigue       },
-            { label: '気分',   value: mood,          setter: setMood,          colorKey: 'mood'          as const, prev: prevMood          },
-            { label: 'やる気', value: motivation,    setter: setMotivation,    colorKey: 'motivation'    as const, prev: prevMotivation    },
-            { label: '集中力', value: concentration, setter: setConcentration, colorKey: 'concentration' as const, prev: prevConcentration },
-          ] as const
-        ).map(({ label, value, setter, colorKey, prev }) => (
-          <div className="mb-3" key={label}>
-            <label className="form-label d-flex justify-content-between align-items-center">
-              <span>{label}</span>
-              <span className="d-flex align-items-center gap-2">
-                {hasPrev && (
-                  <span
-                    className="text-muted"
-                    style={{ fontSize: '0.75rem' }}
-                    title="前回の記録値"
-                  >
-                    前回: {prev}
-                  </span>
-                )}
-                <span
-                  className="badge"
                   style={{
-                    backgroundColor: SLIDER_COLORS[colorKey],
-                    color: '#fff',
-                    minWidth: '2.5rem',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: '2px',
+                    padding: '8px 12px',
+                    minWidth: '64px',
                   }}
                 >
-                  {value}
-                </span>
-              </span>
-            </label>
-            <input
-              type="range"
-              className="form-range"
-              min={0}
-              max={100}
-              value={value}
-              onChange={(e) => setter(Number(e.target.value))}
-              style={{ accentColor: SLIDER_COLORS[colorKey] }}
-            />
-          </div>
-        ))}
+                  {eventSending[item.item_id] ? (
+                    <span className="spinner-border spinner-border-sm" role="status" />
+                  ) : (
+                    <>
+                      <span style={{ fontSize: '1.4rem', lineHeight: 1 }}>{item.icon ?? '✓'}</span>
+                      <span style={{ fontSize: '0.7rem' }}>{item.label}</span>
+                    </>
+                  )}
+                </button>
+              ))}
 
-        {/* Custom form items */}
-        {formItems.length > 0 && (
-          <div className="mb-3">
-            <label className="form-label text-muted">カスタム項目</label>
-            {formItems.map((item) => (
-              <div className="mb-2" key={item.item_id}>
-                {item.type === 'checkbox' && (
-                  <div className="form-check">
-                    <input
-                      type="checkbox"
-                      className="form-check-input"
-                      id={`custom-${item.item_id}`}
-                      checked={Boolean(customValues[item.item_id])}
-                      onChange={(e) => setCustomValue(item.item_id, e.target.checked)}
-                    />
-                    <label className="form-check-label" htmlFor={`custom-${item.item_id}`}>
-                      {item.icon && <span className="me-1">{item.icon}</span>}
-                      {item.label}
-                    </label>
+            {eventItems
+              .filter((item) => item.type !== 'checkbox')
+              .map((item) => (
+                <div
+                  key={item.item_id}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '4px',
+                    padding: '6px 10px',
+                    border: '1px solid #dee2e6',
+                    borderRadius: '6px',
+                    minWidth: '100px',
+                    maxWidth: '140px',
+                    backgroundColor: '#f8f9fa',
+                  }}
+                >
+                  <span style={{ fontSize: '0.72rem', color: '#6c757d', fontWeight: 500 }}>
+                    {item.icon ? `${item.icon} ` : ''}{item.label}
+                    {item.unit ? ` (${item.unit})` : ''}
+                  </span>
+                  <input
+                    type={item.type === 'text' ? 'text' : 'number'}
+                    className="form-control form-control-sm"
+                    placeholder={item.unit ?? '値'}
+                    value={eventInputs[item.item_id] ?? ''}
+                    onChange={(e) =>
+                      setEventInputs((prev) => ({ ...prev, [item.item_id]: e.target.value }))
+                    }
+                    style={{ fontSize: '0.8rem', padding: '2px 6px' }}
+                  />
+                  <button
+                    className="btn btn-outline-success btn-sm"
+                    onClick={() => handleQuickEvent(item)}
+                    disabled={eventSending[item.item_id]}
+                    style={{ fontSize: '0.72rem', padding: '2px 6px' }}
+                  >
+                    {eventSending[item.item_id] ? '…' : '記録'}
+                  </button>
+                </div>
+              ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ── Daily Form ────────────────────────────────────────── */}
+      <Card variant="outlined" sx={{ mb: 2, borderRadius: 2 }}>
+        <CardContent sx={{ pt: 1.5, px: 2 }}>
+          <Typography variant="h6" color="success.main" sx={{ mb: 2, fontWeight: 700 }}>
+            体調記録
+          </Typography>
+          <form onSubmit={handleSubmit}>
+            {/* MUI Sliders */}
+            {(
+              [
+                { label: '疲労感', value: fatigue,       setter: setFatigue,       colorKey: 'fatigue'       as const, prev: prevFatigue       },
+                { label: '気分',   value: mood,          setter: setMood,          colorKey: 'mood'          as const, prev: prevMood          },
+                { label: 'やる気', value: motivation,    setter: setMotivation,    colorKey: 'motivation'    as const, prev: prevMotivation    },
+                { label: '集中力', value: concentration, setter: setConcentration, colorKey: 'concentration' as const, prev: prevConcentration },
+              ] as const
+            ).map(({ label, value, setter, colorKey, prev }) => (
+              <div className="mb-2" key={label}>
+                <div className="d-flex justify-content-between align-items-center mb-1">
+                  <Typography variant="body2" sx={{ fontWeight: 500 }}>{label}</Typography>
+                  <div className="d-flex align-items-center gap-2">
+                    {hasPrev && (
+                      <Typography variant="caption" color="text.secondary" title="前回の記録値">
+                        前回: {prev}
+                      </Typography>
+                    )}
+                    <span
+                      className="badge"
+                      style={{
+                        backgroundColor: SLIDER_COLORS[colorKey],
+                        color: '#fff',
+                        minWidth: '2.5rem',
+                      }}
+                    >
+                      {value}
+                    </span>
                   </div>
-                )}
-                {(item.type === 'slider') && (
-                  <div>
-                    <label className="form-label d-flex justify-content-between">
-                      <span>{item.icon && <span className="me-1">{item.icon}</span>}{item.label}</span>
-                      <span className="badge bg-secondary">
-                        {customValues[item.item_id] ?? item.min ?? 0}
-                        {item.unit && ` ${item.unit}`}
-                      </span>
-                    </label>
-                    <input
-                      type="range"
-                      className="form-range"
-                      min={item.min ?? 0}
-                      max={item.max ?? 100}
-                      value={Number(customValues[item.item_id] ?? item.min ?? 0)}
-                      onChange={(e) => setCustomValue(item.item_id, Number(e.target.value))}
-                    />
-                  </div>
-                )}
-                {item.type === 'number' && (
-                  <div>
-                    <label className="form-label">
-                      {item.icon && <span className="me-1">{item.icon}</span>}
-                      {item.label}
-                    </label>
-                    <div className="input-group" style={{ maxWidth: '200px' }}>
-                      <input
-                        type="number"
-                        className="form-control"
-                        min={item.min}
-                        max={item.max}
-                        value={String(customValues[item.item_id] ?? '')}
-                        onChange={(e) => setCustomValue(item.item_id, Number(e.target.value))}
-                        placeholder="0"
-                      />
-                      {item.unit && <span className="input-group-text">{item.unit}</span>}
-                    </div>
-                  </div>
-                )}
-                {item.type === 'text' && (
-                  <div>
-                    <label className="form-label">
-                      {item.icon && <span className="me-1">{item.icon}</span>}
-                      {item.label}
-                    </label>
-                    <input
-                      type="text"
-                      className="form-control"
-                      value={String(customValues[item.item_id] ?? '')}
-                      onChange={(e) => setCustomValue(item.item_id, e.target.value)}
-                    />
-                  </div>
-                )}
+                </div>
+                <Slider
+                  min={0}
+                  max={100}
+                  value={value}
+                  onChange={(_, v) => setter(v as number)}
+                  sx={{
+                    color: SLIDER_COLORS[colorKey],
+                    py: 0.5,
+                    '& .MuiSlider-thumb': { width: 20, height: 20 },
+                  }}
+                />
               </div>
             ))}
-          </div>
-        )}
 
-        {/* Note */}
-        <div className="mb-4">
-          <label className="form-label d-flex justify-content-between">
-            <span>メモ</span>
-            <span className="text-muted small">{note.length}/280</span>
-          </label>
-          <textarea
-            className="form-control"
-            rows={3}
-            maxLength={280}
-            value={note}
-            onChange={(e) => setNote(e.target.value)}
-            placeholder="体調についてメモ（任意）"
-          />
-        </div>
+            {/* Custom form items */}
+            {formItems.length > 0 && (
+              <div className="mb-3">
+                <label className="form-label text-muted">カスタム項目</label>
+                {formItems.map((item) => (
+                  <div className="mb-2" key={item.item_id}>
+                    {item.type === 'checkbox' && (
+                      <div className="form-check">
+                        <input
+                          type="checkbox"
+                          className="form-check-input"
+                          id={`custom-${item.item_id}`}
+                          checked={Boolean(customValues[item.item_id])}
+                          onChange={(e) => setCustomValue(item.item_id, e.target.checked)}
+                        />
+                        <label className="form-check-label" htmlFor={`custom-${item.item_id}`}>
+                          {item.icon && <span className="me-1">{item.icon}</span>}
+                          {item.label}
+                        </label>
+                      </div>
+                    )}
+                    {(item.type === 'slider') && (
+                      <div>
+                        <label className="form-label d-flex justify-content-between">
+                          <span>{item.icon && <span className="me-1">{item.icon}</span>}{item.label}</span>
+                          <span className="badge bg-secondary">
+                            {customValues[item.item_id] ?? item.min ?? 0}
+                            {item.unit && ` ${item.unit}`}
+                          </span>
+                        </label>
+                        <Slider
+                          min={item.min ?? 0}
+                          max={item.max ?? 100}
+                          value={Number(customValues[item.item_id] ?? item.min ?? 0)}
+                          onChange={(_, v) => setCustomValue(item.item_id, v as number)}
+                          sx={{ color: '#6c757d', py: 0.5 }}
+                        />
+                      </div>
+                    )}
+                    {item.type === 'number' && (
+                      <div>
+                        <label className="form-label">
+                          {item.icon && <span className="me-1">{item.icon}</span>}
+                          {item.label}
+                        </label>
+                        <div className="input-group" style={{ maxWidth: '200px' }}>
+                          <input
+                            type="number"
+                            className="form-control"
+                            min={item.min}
+                            max={item.max}
+                            value={String(customValues[item.item_id] ?? '')}
+                            onChange={(e) => setCustomValue(item.item_id, Number(e.target.value))}
+                            placeholder="0"
+                          />
+                          {item.unit && <span className="input-group-text">{item.unit}</span>}
+                        </div>
+                      </div>
+                    )}
+                    {item.type === 'text' && (
+                      <div>
+                        <label className="form-label">
+                          {item.icon && <span className="me-1">{item.icon}</span>}
+                          {item.label}
+                        </label>
+                        <input
+                          type="text"
+                          className="form-control"
+                          value={String(customValues[item.item_id] ?? '')}
+                          onChange={(e) => setCustomValue(item.item_id, e.target.value)}
+                        />
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
 
-        <button type="submit" className="btn btn-success w-100" disabled={submitting}>
-          {submitting ? (
-            <>
-              <span className="spinner-border spinner-border-sm me-2" role="status" />
-              送信中...
-            </>
-          ) : (
-            '記録する'
-          )}
-        </button>
-      </form>
+            {/* Note - MUI TextField */}
+            <TextField
+              label="メモ"
+              multiline
+              rows={3}
+              fullWidth
+              variant="outlined"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              inputProps={{ maxLength: 280 }}
+              helperText={`${note.length}/280`}
+              placeholder="体調についてメモ（任意）"
+              sx={{
+                mb: 2,
+                '& .MuiOutlinedInput-root': {
+                  '&.Mui-focused fieldset': { borderColor: '#198754' },
+                },
+                '& .MuiInputLabel-root.Mui-focused': { color: '#198754' },
+              }}
+            />
+
+            <button type="submit" className="btn btn-success w-100" disabled={submitting}>
+              {submitting ? (
+                <>
+                  <span className="spinner-border spinner-border-sm me-2" role="status" />
+                  送信中...
+                </>
+              ) : (
+                '記録する'
+              )}
+            </button>
+          </form>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/frontend/src/components/RecordHistory.tsx
+++ b/frontend/src/components/RecordHistory.tsx
@@ -1,4 +1,7 @@
 import { useState } from 'react'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import Typography from '@mui/material/Typography'
 import { deleteRecord } from '../api'
 import { useAuth } from '../hooks/useAuth'
 import type { LatestRecord } from '../types'
@@ -46,43 +49,57 @@ export default function RecordHistory({ records, onDeleted }: Props) {
   if (records.length === 0) return null
 
   return (
-    <div className="mt-4">
-      <h2 className="h6 text-muted mb-2">最近の記録</h2>
+    <div className="mt-2">
+      <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1.5, fontWeight: 600 }}>
+        最近の記録
+      </Typography>
 
       {error && (
         <div className="alert alert-danger py-1 small">{error}</div>
       )}
 
-      <ul className="list-group list-group-flush">
+      <div className="d-flex flex-column gap-2">
         {displayed.map((record) => (
-          <li
+          <Card
             key={record.id}
-            className="list-group-item d-flex justify-content-between align-items-center px-0 py-2"
+            variant="outlined"
+            sx={{ borderRadius: 2 }}
           >
-            <div className="d-flex flex-column">
-              <span className="small fw-semibold">
-                {formatTime(record.recorded_at)}
-                <span className={`badge ms-2 ${record.record_type === 'event' ? 'bg-info' : 'bg-success'} bg-opacity-75`}>
-                  {record.record_type === 'event' ? 'イベント' : '日次'}
-                </span>
-              </span>
-              <RecordSummary record={record} />
-            </div>
-            <button
-              className="btn btn-sm btn-outline-danger"
-              onClick={() => handleDelete(record)}
-              disabled={deleting === record.id}
-              title="削除"
+            <CardContent
+              sx={{
+                py: '10px !important',
+                px: 2,
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}
             >
-              {deleting === record.id ? '…' : '🗑'}
-            </button>
-          </li>
+              <div className="d-flex flex-column">
+                <span className="small fw-semibold">
+                  {formatTime(record.recorded_at)}
+                  <span className={`badge ms-2 ${record.record_type === 'event' ? 'bg-info' : 'bg-success'} bg-opacity-75`}>
+                    {record.record_type === 'event' ? 'イベント' : record.record_type === 'status' ? 'ステータス' : '日次'}
+                  </span>
+                </span>
+                <RecordSummary record={record} />
+              </div>
+              <button
+                className="btn btn-sm btn-outline-danger"
+                onClick={() => handleDelete(record)}
+                disabled={deleting === record.id}
+                title="削除"
+                style={{ flexShrink: 0 }}
+              >
+                {deleting === record.id ? '…' : '🗑'}
+              </button>
+            </CardContent>
+          </Card>
         ))}
-      </ul>
+      </div>
 
       {records.length > 5 && (
         <button
-          className="btn btn-sm btn-link text-muted p-0 mt-1"
+          className="btn btn-sm btn-link text-muted p-0 mt-2"
           onClick={() => setExpanded((v) => !v)}
         >
           {expanded ? '折りたたむ' : `もっと見る（${records.length} 件中 5 件表示）`}


### PR DESCRIPTION
## 関連イシュー
Closes #96

## 変更内容

### App.tsx
- 上部タブバー → **MUI BottomNavigation** に置き換え（画面下部）
- `page !== 0` 時に **FAB**（Floating Action Button）を表示、タップで記録ページへジャンプ
- スワイプ操作は維持
- 各ページに `paddingBottom: 72px` を追加し Bottom Navigation と重ならないよう調整

### HealthForm.tsx
- ステータス・クイックイベント・体調記録の各セクションを **MUI Card** で包む
- Bootstrap `input[type=range]` → **MUI Slider**（色は既存 SLIDER_COLORS を継承）
- メモ欄 `<textarea>` → **MUI TextField**（multiline）

### RecordHistory.tsx
- 各記録エントリを **MUI Card** に変更
- 日次 / イベント / ステータスのバッジ識別を追加

## 依存追加
```
@mui/material @emotion/react @emotion/styled
```

## テスト確認
- [x] `npx tsc --noEmit` → エラーなし
- [x] `npm test` → 19 tests passed
- [x] `npm run build` → ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)