### PR TITLE
feat: dbt docs の自動生成と S3 静的ホスティングを導入 (#104)

### DIFF
--- a/.github/workflows/dbt-docs.yml
+++ b/.github/workflows/dbt-docs.yml
@@ -1,0 +1,81 @@
+name: dbt Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "data/dbt/**"
+  workflow_dispatch:  # 手動実行も可能
+
+env:
+  AWS_REGION: ap-northeast-1
+  DBT_DOCS_BUCKET: health-logger-prod-dbt-docs
+  # dbt が Athena クエリ結果を置く S3 パス
+  DBT_STAGING_DIR: s3://health-logger-prod-health-export/dbt-docs-athena-results/
+
+jobs:
+  generate-and-deploy:
+    name: Generate dbt docs and deploy to S3
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_PROD }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dbt
+        run: |
+          pip install \
+            "dbt-core==1.10.5" \
+            "dbt-athena-community==1.9.4" \
+            --quiet
+
+      - name: Configure dbt profiles
+        run: |
+          mkdir -p ~/.dbt
+          cat > ~/.dbt/profiles.yml <<EOF
+          health_logger:
+            target: prod
+            outputs:
+              prod:
+                type: athena
+                database: AwsDataCatalog
+                schema: health_logger_prod_health_logs
+                s3_staging_dir: ${{ env.DBT_STAGING_DIR }}
+                region_name: ${{ env.AWS_REGION }}
+                work_group: primary
+                threads: 4
+          EOF
+
+      - name: Install dbt packages
+        working-directory: data/dbt
+        run: dbt deps
+
+      - name: Generate dbt docs
+        working-directory: data/dbt
+        run: dbt docs generate --profiles-dir ~/.dbt
+
+      - name: Deploy to S3
+        working-directory: data/dbt
+        run: |
+          aws s3 sync target/ s3://${{ env.DBT_DOCS_BUCKET }}/ \
+            --exclude "*.log" \
+            --exclude "run_results.json" \
+            --delete
+
+      - name: Output docs URL
+        run: |
+          echo "📚 dbt docs: http://${{ env.DBT_DOCS_BUCKET }}.s3-website-ap-northeast-1.amazonaws.com"

--- a/scripts/dbt.sh
+++ b/scripts/dbt.sh
@@ -11,17 +11,49 @@
 # 使い方:
 #   ./scripts/dbt.sh run --select staging
 #   ./scripts/dbt.sh test
+#   ./scripts/dbt.sh docs generate   # catalog.json + manifest.json + index.html を生成
+#   ./scripts/dbt.sh docs serve      # http://localhost:8080 でドキュメントサイトを起動
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "${SCRIPT_DIR}")"
 COMPOSE_FILE="${PROJECT_ROOT}/docker-compose.dbt.yml"
 
-# dbt コンテナが起動していなければ起動する
-if ! docker compose -f "${COMPOSE_FILE}" ps dbt --status running 2>/dev/null | grep -q "running"; then
-  echo "[dbt-wrapper] dbt コンテナが起動していません。起動します..." >&2
-  docker compose -f "${COMPOSE_FILE}" up -d dbt >&2
-  sleep 5
+_ensure_dbt_running() {
+  if ! docker compose -f "${COMPOSE_FILE}" ps dbt --status running 2>/dev/null | grep -q "running"; then
+    echo "[dbt-wrapper] dbt コンテナが起動していません。起動します..." >&2
+    docker compose -f "${COMPOSE_FILE}" up -d dbt >&2
+    sleep 5
+  fi
+}
+
+# docs サブコマンドの処理
+# 使い方:
+#   ./scripts/dbt.sh docs generate  → catalog.json + manifest.json + index.html を生成
+#   ./scripts/dbt.sh docs serve     → http://localhost:8080 でドキュメントサイトを起動
+if [[ "$1" == "docs" ]]; then
+  DOCS_CMD="${2:-generate}"
+  shift 2 2>/dev/null || shift 1
+
+  _ensure_dbt_running
+
+  case "${DOCS_CMD}" in
+    generate)
+      echo "[dbt-docs] ドキュメントを生成します..." >&2
+      exec docker compose -f "${COMPOSE_FILE}" exec -T dbt dbt docs generate "$@"
+      ;;
+    serve)
+      echo "[dbt-docs] http://localhost:8080 でドキュメントサイトを起動します..." >&2
+      echo "[dbt-docs] 停止するには Ctrl+C を押してください。" >&2
+      exec docker compose -f "${COMPOSE_FILE}" exec dbt dbt docs serve --host 0.0.0.0 --port 8080 "$@"
+      ;;
+    *)
+      echo "Usage: $0 docs [generate|serve]" >&2
+      exit 1
+      ;;
+  esac
 fi
+
+_ensure_dbt_running
 
 # コンテナ内の dbt を実行（引数をそのまま渡す）
 exec docker compose -f "${COMPOSE_FILE}" exec -T dbt dbt "$@"

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -287,6 +287,33 @@ resource "aws_iam_role_policy" "github_actions" {
         Action   = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:Scan"]
         Resource = aws_dynamodb_table.athena_migrations.arn
       },
+      # dbt docs: Athena introspection (catalog.json 生成用)
+      {
+        Effect = "Allow"
+        Action = [
+          "athena:StartQueryExecution",
+          "athena:GetQueryExecution",
+          "athena:GetQueryResults",
+          "glue:GetDatabase", "glue:GetDatabases",
+          "glue:GetTable", "glue:GetTables",
+        ]
+        Resource = ["*"]
+      },
+      # dbt docs: S3 アップロード（dbt-docs バケットへの書き込み）
+      {
+        Effect = "Allow"
+        Action = ["s3:PutObject", "s3:DeleteObject", "s3:ListBucket"]
+        Resource = [
+          aws_s3_bucket.dbt_docs.arn,
+          "${aws_s3_bucket.dbt_docs.arn}/*",
+        ]
+      },
+      # dbt docs generate: Athena クエリ結果の S3 書き込み先
+      {
+        Effect   = "Allow"
+        Action   = ["s3:PutObject", "s3:GetObject", "s3:GetBucketLocation"]
+        Resource = ["arn:aws:s3:::health-logger-prod-health-export/dbt-docs-athena-results/*"]
+      },
     ]
   })
 }
@@ -301,6 +328,46 @@ resource "aws_dynamodb_table" "athena_migrations" {
     name = "migration_name"
     type = "S"
   }
+}
+
+# ── dbt docs 静的ホスティング用 S3 バケット ───────────────────────────────────
+resource "aws_s3_bucket" "dbt_docs" {
+  bucket        = "${local.name}-dbt-docs"
+  force_destroy = true
+  tags          = { Name = "${local.name}-dbt-docs" }
+}
+
+resource "aws_s3_bucket_public_access_block" "dbt_docs" {
+  bucket                  = aws_s3_bucket.dbt_docs.id
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_website_configuration" "dbt_docs" {
+  bucket = aws_s3_bucket.dbt_docs.id
+  index_document { suffix = "index.html" }
+  error_document { key = "index.html" }
+}
+
+resource "aws_s3_bucket_policy" "dbt_docs_public_read" {
+  bucket     = aws_s3_bucket.dbt_docs.id
+  depends_on = [aws_s3_bucket_public_access_block.dbt_docs]
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "PublicReadGetObject"
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = "s3:GetObject"
+      Resource  = "${aws_s3_bucket.dbt_docs.arn}/*"
+    }]
+  })
+}
+
+output "dbt_docs_url" {
+  value = "http://${aws_s3_bucket.dbt_docs.bucket}.s3-website-${var.aws_region}.amazonaws.com"
 }
 
 # ── External environment data ingest (weather/air quality) ────────────────────


### PR DESCRIPTION
## Summary

- `scripts/dbt.sh` に `docs generate` / `docs serve` サブコマンドを追加
- dbt-docs 専用 S3 バケット（`health-logger-prod-dbt-docs`）を Terraform で追加、静的ウェブサイトホスティングを有効化
- GitHub Actions ワークフロー（`dbt-docs.yml`）を追加し、`data/dbt/**` 変更時に自動で `dbt docs generate` → S3 デプロイ

## アクセス URL（terraform apply 後）

```
http://health-logger-prod-dbt-docs.s3-website-ap-northeast-1.amazonaws.com
```

## Test plan

- [ ] `terraform plan` でバケット・ポリシー・IAM 差分が意図通りであることを確認
- [ ] `terraform apply` 後、バケットが作成されること
- [ ] `./scripts/dbt.sh docs generate` でローカルドキュメント生成が成功すること
- [ ] `./scripts/dbt.sh docs serve` で http://localhost:8080 にアクセスできること
- [ ] `data/dbt/` 変更を main にマージして dbt-docs.yml ワークフローが成功すること
- [ ] S3 URL でドキュメントサイトが表示されること

## 注意

`terraform apply` が必要です。適用前に `terraform plan` で差分を確認してください。

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)