### PR TITLE
fix(iam): dbt-docs S3 バケット管理権限を GitHub Actions ロールに追加

### DIFF
--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -294,10 +294,15 @@ resource "aws_iam_role_policy" "github_actions" {
         ]
         Resource = ["*"]
       },
-      # dbt docs: S3 アップロード（dbt-docs バケットへの書き込み）
+      # dbt docs: S3 バケット管理 + アップロード（terraform apply + dbt-docs CI 用）
       {
         Effect = "Allow"
-        Action = ["s3:PutObject", "s3:DeleteObject", "s3:ListBucket"]
+        Action = [
+          "s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket",
+          "s3:PutBucketWebsite", "s3:GetBucketWebsite",
+          "s3:PutBucketPolicy", "s3:GetBucketPolicy",
+          "s3:PutBucketPublicAccessBlock", "s3:GetBucketPublicAccessBlock",
+        ]
         Resource = [
           aws_s3_bucket.dbt_docs.arn,
           "${aws_s3_bucket.dbt_docs.arn}/*",


### PR DESCRIPTION
## Summary
- terraform apply で `aws_s3_bucket_website_configuration` と `aws_s3_bucket_policy` を作成するために必要な IAM 権限が不足していた
- `s3:PutBucketWebsite`, `s3:PutBucketPolicy`, `s3:PutBucketPublicAccessBlock` 等を追加

## 背景
PR #103 マージ後の deploy で以下エラーが発生:
```
Error: creating S3 Bucket (health-logger-prod-dbt-docs) Website Configuration: AccessDenied: s3:PutBucketWebsite
Error: putting S3 Bucket (health-logger-prod-dbt-docs) Policy: AccessDenied: s3:PutBucketPolicy
```

## Test plan
- [ ] CI / Terraform Plan グリーン確認
- [ ] main マージ後の terraform apply でエラーなし確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)