### PR TITLE
fix(iam): Athena マイグレーション S3 書き込みに必要な権限を追加

### DIFF
--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -273,7 +273,7 @@ resource "aws_iam_role_policy" "github_actions" {
       },
       {
         Effect   = "Allow"
-        Action   = ["s3:PutObject", "s3:GetObject", "s3:GetBucketLocation"]
+        Action   = ["s3:PutObject", "s3:GetObject", "s3:GetBucketLocation", "s3:ListBucket", "s3:AbortMultipartUpload", "s3:ListMultipartUploadParts"]
         Resource = ["arn:aws:s3:::health-logger-prod-health-export/athena-migrations/*", "arn:aws:s3:::health-logger-prod-health-export"]
       },
       # Migration tracking DynamoDB table


### PR DESCRIPTION
## Summary
- Athena が S3 に query result を書き込む際に `s3:ListBucket` 等が不足していたため追加
- deploy 時の `001_add_concentration_score` マイグレーション失敗を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)