### PR TITLE
feat: dbt docs デプロイ先を S3 から GitHub Pages に変更

### DIFF
--- a/.github/workflows/dbt-docs.yml
+++ b/.github/workflows/dbt-docs.yml
@@ -9,13 +9,12 @@ on:
 
 env:
   AWS_REGION: ap-northeast-1
-  DBT_DOCS_BUCKET: health-logger-prod-dbt-docs
   # dbt が Athena クエリ結果を置く S3 パス
   DBT_STAGING_DIR: s3://health-logger-prod-health-export/dbt-docs-athena-results/
 
 jobs:
-  generate-and-deploy:
-    name: Generate dbt docs and deploy to S3
+  generate:
+    name: Generate dbt docs
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -68,14 +67,23 @@ jobs:
         working-directory: data/dbt
         run: dbt docs generate --profiles-dir ~/.dbt
 
-      - name: Deploy to S3
-        working-directory: data/dbt
-        run: |
-          aws s3 sync target/ s3://${{ env.DBT_DOCS_BUCKET }}/ \
-            --exclude "*.log" \
-            --exclude "run_results.json" \
-            --delete
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: data/dbt/target
 
-      - name: Output docs URL
-        run: |
-          echo "📚 dbt docs: http://${{ env.DBT_DOCS_BUCKET }}.s3-website-ap-northeast-1.amazonaws.com"
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: generate
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- `dbt docs generate` の出力を GitHub Pages にデプロイするよう変更
- S3 sync → `actions/upload-pages-artifact` + `actions/deploy-pages` に置き換え
- URL: https://rikunisikawa.github.io/health-logger/

## Test plan
- [ ] CI グリーン確認
- [ ] main マージ後に GitHub Pages へのデプロイ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)