### PR TITLE
fix(ci): terraform.yml を PR のみのトリガーに変更し deploy.yml との競合を解消

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,18 +6,11 @@ on:
     paths:
       - "terraform/**"
       - "migrations/athena/**"
-  push:
-    branches: [main]
-    paths:
-      - "terraform/**"
-      - "migrations/athena/**"
 
-# 同一ブランチでの並行実行を防ぎ state lock 競合を回避する
-# cancel-in-progress: PR は新しい push で古いランをキャンセル
-# main への push は直列化（キャンセルしない）
+# PR で同一ブランチへの新しい push が来たら古いランをキャンセルする
 concurrency:
   group: terraform-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 env:
   TF_VERSION: "1.12.0"
@@ -95,17 +88,3 @@ jobs:
               });
             }
 
-      - name: Terraform Apply (main branch only)
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: terraform apply -auto-approve tfplan
-
-      - name: Run Athena schema migrations (main branch only)
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        working-directory: ${{ github.workspace }}
-        run: |
-          pip install boto3 --quiet
-          python3 scripts/athena-migrate.py
-        env:
-          ATHENA_DATABASE: health_logger_prod_health_logs
-          ATHENA_OUTPUT_BUCKET: health-logger-prod-health-export
-          MIGRATION_TRACKING_TABLE: health-logger-prod-athena-migrations


### PR DESCRIPTION
## Summary

- `terraform.yml` の `push` トリガーを削除 — PR のみで実行（plan + PR コメント）
- `terraform apply` / Athena migration ステップを削除
- `deploy.yml` が main push 時の apply と migration を一元管理するように整理

## 問題の背景

PR #143 マージ後、Lambda 関数が `No module named 'handler'` で全断した。

原因は `terraform.yml` と `deploy.yml` が同じ main push で並行して `terraform apply` を実行し、  
`terraform.yml` が `lambda_s3_keys=placeholder` で apply → Lambda を 212B のスタブに上書き。

```
deploy.yml  (2m12s)  → 正しい zip で Lambda 更新 ✅
terraform.yml (10m18s) → placeholder で Lambda を上書き ❌ (08:28 UTC)
```

## Test plan

- [ ] PR マージ後に `deploy.yml` のみが起動し、Lambda が正しい zip でデプロイされること
- [ ] 次回 terraform PR 作成時に terraform.yml が plan + PR コメントを実行すること
- [ ] `terraform.yml` が main push では起動しないこと

Fixes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)