### PR TITLE
fix: ステータス履歴クエリの dt カラム参照を DATE(recorded_at) に修正

### DIFF
--- a/frontend/src/components/StatusManagerModal.tsx
+++ b/frontend/src/components/StatusManagerModal.tsx
@@ -1,67 +1,77 @@
-import { useCallback, useEffect, useState } from 'react'
-import Dialog from '@mui/material/Dialog'
-import DialogTitle from '@mui/material/DialogTitle'
-import DialogContent from '@mui/material/DialogContent'
-import DialogActions from '@mui/material/DialogActions'
-import IconButton from '@mui/material/IconButton'
-import Tab from '@mui/material/Tab'
-import Tabs from '@mui/material/Tabs'
-import Typography from '@mui/material/Typography'
-import { createRecord, deleteRecord, getStatusRecords } from '../api'
-import type { CustomFieldValue, HealthRecordInput, ItemConfig, LatestRecord } from '../types'
-import type { ToastVariant } from './HealthForm'
+import { useCallback, useEffect, useState } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import IconButton from "@mui/material/IconButton";
+import Tab from "@mui/material/Tab";
+import Tabs from "@mui/material/Tabs";
+import Typography from "@mui/material/Typography";
+import { createRecord, deleteRecord, getStatusRecords } from "../api";
+import type {
+  CustomFieldValue,
+  HealthRecordInput,
+  ItemConfig,
+  LatestRecord,
+} from "../types";
+import type { ToastVariant } from "./HealthForm";
 
 // ── types ────────────────────────────────────────────────────────────────────
 
 interface StatusPeriod {
-  id_on: string
-  id_off?: string
-  item_id: string
-  label: string
-  startAt: Date
-  endAt?: Date
+  id_on: string;
+  id_off?: string;
+  item_id: string;
+  label: string;
+  startAt: Date;
+  endAt?: Date;
 }
 
 interface EditTarget {
-  period: StatusPeriod
-  editType: 'start' | 'end'
+  period: StatusPeriod;
+  editType: "start" | "end";
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 function toDatetimeLocal(date: Date): string {
-  const pad = (n: number) => String(n).padStart(2, '0')
+  const pad = (n: number) => String(n).padStart(2, "0");
   return (
     `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
     `T${pad(date.getHours())}:${pad(date.getMinutes())}`
-  )
+  );
 }
 
 function toYMD(date: Date): string {
-  return date.toLocaleDateString('sv')  // "YYYY-MM-DD"
+  return date.toLocaleDateString("sv"); // "YYYY-MM-DD"
 }
 
 function addDays(base: Date, days: number): Date {
-  const d = new Date(base)
-  d.setDate(d.getDate() + days)
-  return d
+  const d = new Date(base);
+  d.setDate(d.getDate() + days);
+  return d;
 }
 
 function parseStatusPeriods(records: LatestRecord[]): StatusPeriod[] {
   const sorted = [...records].sort(
-    (a, b) => new Date(a.recorded_at).getTime() - new Date(b.recorded_at).getTime(),
-  )
+    (a, b) =>
+      new Date(a.recorded_at).getTime() - new Date(b.recorded_at).getTime(),
+  );
 
-  const open: Record<string, StatusPeriod> = {}
-  const periods: StatusPeriod[] = []
+  const open: Record<string, StatusPeriod> = {};
+  const periods: StatusPeriod[] = [];
 
   for (const rec of sorted) {
-    let fields: CustomFieldValue[] = []
-    try { fields = JSON.parse(rec.custom_fields) } catch { continue }
+    let fields: CustomFieldValue[] = [];
+    try {
+      fields = JSON.parse(rec.custom_fields);
+    } catch {
+      continue;
+    }
 
     for (const field of fields) {
-      const isOn = field.value === true || field.value === 'true'
-      const isOff = field.value === false || field.value === 'false'
+      const isOn = field.value === true || field.value === "true";
+      const isOff = field.value === false || field.value === "false";
 
       if (isOn) {
         open[field.item_id] = {
@@ -69,137 +79,183 @@ function parseStatusPeriods(records: LatestRecord[]): StatusPeriod[] {
           item_id: field.item_id,
           label: String(field.label),
           startAt: new Date(rec.recorded_at),
-        }
+        };
       } else if (isOff && open[field.item_id]) {
-        periods.push({ ...open[field.item_id], id_off: rec.id, endAt: new Date(rec.recorded_at) })
-        delete open[field.item_id]
+        periods.push({
+          ...open[field.item_id],
+          id_off: rec.id,
+          endAt: new Date(rec.recorded_at),
+        });
+        delete open[field.item_id];
       }
     }
   }
 
-  for (const p of Object.values(open)) periods.push(p)
-  return periods
+  for (const p of Object.values(open)) periods.push(p);
+  return periods;
 }
 
 // ── Gantt chart ───────────────────────────────────────────────────────────────
 
-const AXIS_HOURS = [0, 4, 8, 12, 16, 20, 24]
+const AXIS_HOURS = [0, 4, 8, 12, 16, 20, 24];
 
 function timeToPercent(dt: Date, axisStartH: number, axisEndH: number): number {
-  const minutes = dt.getHours() * 60 + dt.getMinutes()
-  return Math.max(0, Math.min(100, (minutes - axisStartH * 60) / ((axisEndH - axisStartH) * 60) * 100))
+  const minutes = dt.getHours() * 60 + dt.getMinutes();
+  return Math.max(
+    0,
+    Math.min(
+      100,
+      ((minutes - axisStartH * 60) / ((axisEndH - axisStartH) * 60)) * 100,
+    ),
+  );
 }
 
 interface GanttRowProps {
-  label: string
-  periods: StatusPeriod[]
-  dateStr: string       // "YYYY-MM-DD"
-  axisStartH: number
-  axisEndH: number
-  onBarClick: (p: StatusPeriod) => void
+  label: string;
+  periods: StatusPeriod[];
+  dateStr: string; // "YYYY-MM-DD"
+  axisStartH: number;
+  axisEndH: number;
+  onBarClick: (p: StatusPeriod) => void;
 }
 
-function GanttRow({ label, periods, dateStr, axisStartH, axisEndH, onBarClick }: GanttRowProps) {
-  const now = new Date()
+function GanttRow({
+  label,
+  periods,
+  dateStr,
+  axisStartH,
+  axisEndH,
+  onBarClick,
+}: GanttRowProps) {
+  const now = new Date();
 
   const rowPeriods = periods.filter((p) => {
-    const startDate = toYMD(p.startAt)
-    const endDate = p.endAt ? toYMD(p.endAt) : toYMD(now)
-    return startDate <= dateStr && endDate >= dateStr
-  })
+    const startDate = toYMD(p.startAt);
+    const endDate = p.endAt ? toYMD(p.endAt) : toYMD(now);
+    return startDate <= dateStr && endDate >= dateStr;
+  });
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', marginBottom: 6 }}>
-      <div style={{ width: 72, fontSize: '0.72rem', flexShrink: 0, color: '#495057' }}>{label}</div>
+    <div style={{ display: "flex", alignItems: "center", marginBottom: 6 }}>
+      <div
+        style={{
+          width: 72,
+          fontSize: "0.72rem",
+          flexShrink: 0,
+          color: "#495057",
+        }}
+      >
+        {label}
+      </div>
       <div
         style={{
           flex: 1,
-          position: 'relative',
+          position: "relative",
           height: 24,
-          backgroundColor: '#f1f3f5',
+          backgroundColor: "#f1f3f5",
           borderRadius: 4,
         }}
       >
         {rowPeriods.map((period) => {
-          const effectiveEnd = period.endAt ?? now
-          const isActive = !period.endAt
+          const effectiveEnd = period.endAt ?? now;
+          const isActive = !period.endAt;
 
           // Clamp times to the selected date and axis range
-          const dayStart = new Date(`${dateStr}T00:00:00`)
-          const dayEnd = new Date(`${dateStr}T23:59:59`)
-          const clampedStart = new Date(Math.max(period.startAt.getTime(), dayStart.getTime()))
-          const clampedEnd = new Date(Math.min(effectiveEnd.getTime(), dayEnd.getTime()))
+          const dayStart = new Date(`${dateStr}T00:00:00`);
+          const dayEnd = new Date(`${dateStr}T23:59:59`);
+          const clampedStart = new Date(
+            Math.max(period.startAt.getTime(), dayStart.getTime()),
+          );
+          const clampedEnd = new Date(
+            Math.min(effectiveEnd.getTime(), dayEnd.getTime()),
+          );
 
-          const leftPct = timeToPercent(clampedStart, axisStartH, axisEndH)
-          const rightPct = timeToPercent(clampedEnd, axisStartH, axisEndH)
-          const widthPct = Math.max(0, rightPct - leftPct)
-          if (widthPct <= 0) return null
+          const leftPct = timeToPercent(clampedStart, axisStartH, axisEndH);
+          const rightPct = timeToPercent(clampedEnd, axisStartH, axisEndH);
+          const widthPct = Math.max(0, rightPct - leftPct);
+          if (widthPct <= 0) return null;
 
           return (
             <div
               key={period.id_on}
               onClick={() => onBarClick(period)}
-              title={`${period.startAt.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })} - ${period.endAt ? period.endAt.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' }) : '継続中'}`}
+              title={`${period.startAt.toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" })} - ${period.endAt ? period.endAt.toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" }) : "継続中"}`}
               style={{
-                position: 'absolute',
+                position: "absolute",
                 left: `${leftPct}%`,
                 width: `${widthPct}%`,
-                height: '100%',
-                backgroundColor: isActive ? '#ffc107' : '#fd7e14',
+                height: "100%",
+                backgroundColor: isActive ? "#ffc107" : "#fd7e14",
                 borderRadius: 4,
-                cursor: 'pointer',
+                cursor: "pointer",
                 minWidth: 4,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                overflow: 'hidden',
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                overflow: "hidden",
               }}
             >
               {isActive && widthPct > 8 && (
-                <span style={{ fontSize: '0.55rem', color: '#fff', fontWeight: 700, whiteSpace: 'nowrap' }}>
+                <span
+                  style={{
+                    fontSize: "0.55rem",
+                    color: "#fff",
+                    fontWeight: 700,
+                    whiteSpace: "nowrap",
+                  }}
+                >
                   継続中
                 </span>
               )}
             </div>
-          )
+          );
         })}
       </div>
     </div>
-  )
+  );
 }
 
 interface GanttChartProps {
-  periods: StatusPeriod[]
-  statusLabels: { item_id: string; label: string }[]
-  dateStr: string
-  axisStartH: number
-  axisEndH: number
-  onBarClick: (p: StatusPeriod) => void
+  periods: StatusPeriod[];
+  statusLabels: { item_id: string; label: string }[];
+  dateStr: string;
+  axisStartH: number;
+  axisEndH: number;
+  onBarClick: (p: StatusPeriod) => void;
 }
 
-function GanttChart({ periods, statusLabels, dateStr, axisStartH, axisEndH, onBarClick }: GanttChartProps) {
-  const visibleHours = AXIS_HOURS.filter((h) => h >= axisStartH && h <= axisEndH)
+function GanttChart({
+  periods,
+  statusLabels,
+  dateStr,
+  axisStartH,
+  axisEndH,
+  onBarClick,
+}: GanttChartProps) {
+  const visibleHours = AXIS_HOURS.filter(
+    (h) => h >= axisStartH && h <= axisEndH,
+  );
 
   return (
     <div>
       {/* Time axis */}
-      <div style={{ display: 'flex', paddingLeft: 72, marginBottom: 4 }}>
+      <div style={{ display: "flex", paddingLeft: 72, marginBottom: 4 }}>
         {visibleHours.map((h, i) => (
           <div
             key={h}
             style={{
               flex: i < visibleHours.length - 1 ? 1 : 0,
-              fontSize: '0.65rem',
-              color: '#868e96',
+              fontSize: "0.65rem",
+              color: "#868e96",
             }}
           >
-            {`${String(h).padStart(2, '0')}:00`}
+            {`${String(h).padStart(2, "0")}:00`}
           </div>
         ))}
       </div>
 
       {/* Grid lines background */}
-      <div style={{ position: 'relative' }}>
+      <div style={{ position: "relative" }}>
         {statusLabels.map(({ item_id, label }) => (
           <GanttRow
             key={item_id}
@@ -213,76 +269,93 @@ function GanttChart({ periods, statusLabels, dateStr, axisStartH, axisEndH, onBa
         ))}
       </div>
     </div>
-  )
+  );
 }
 
 // ── edit modal ────────────────────────────────────────────────────────────────
 
 interface EditModalProps {
-  target: EditTarget
-  token: string
-  onSaved: () => void
-  onClose: () => void
-  onToast: (message: string, variant: ToastVariant) => void
+  target: EditTarget;
+  token: string;
+  onSaved: () => void;
+  onClose: () => void;
+  onToast: (message: string, variant: ToastVariant) => void;
 }
 
-function EditModal({ target, token, onSaved, onClose, onToast }: EditModalProps) {
-  const { period, editType } = target
-  const isEnd = editType === 'end'
+function EditModal({
+  target,
+  token,
+  onSaved,
+  onClose,
+  onToast,
+}: EditModalProps) {
+  const { period, editType } = target;
+  const isEnd = editType === "end";
   const defaultDt = isEnd
-    ? (period.endAt ? toDatetimeLocal(period.endAt) : toDatetimeLocal(new Date()))
-    : toDatetimeLocal(period.startAt)
-  const [value, setValue] = useState(defaultDt)
-  const [saving, setSaving] = useState(false)
+    ? period.endAt
+      ? toDatetimeLocal(period.endAt)
+      : toDatetimeLocal(new Date())
+    : toDatetimeLocal(period.startAt);
+  const [value, setValue] = useState(defaultDt);
+  const [saving, setSaving] = useState(false);
 
   const handleSave = async () => {
-    setSaving(true)
-    const newRecordedAt = new Date(value).toISOString()
-    const base: Omit<HealthRecordInput, 'custom_fields'> = {
-      record_type: 'status',
+    setSaving(true);
+    const newRecordedAt = new Date(value).toISOString();
+    const base: Omit<HealthRecordInput, "custom_fields"> = {
+      record_type: "status",
       flags: 0,
-      note: '',
+      note: "",
       recorded_at: newRecordedAt,
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       device_id: navigator.userAgent.slice(0, 100),
-      app_version: '1.0.0',
-    }
-    const fieldValue = isEnd ? false : true
+      app_version: "1.0.0",
+    };
+    const fieldValue = isEnd ? false : true;
     const newRecord: HealthRecordInput = {
       ...base,
       custom_fields: [
-        { item_id: period.item_id, label: period.label, type: 'checkbox', value: fieldValue },
+        {
+          item_id: period.item_id,
+          label: period.label,
+          type: "checkbox",
+          value: fieldValue,
+        },
       ],
-    }
+    };
 
     try {
       // Delete old record
-      const idToDelete = isEnd ? period.id_off : period.id_on
-      if (idToDelete) await deleteRecord(idToDelete, token)
+      const idToDelete = isEnd ? period.id_off : period.id_on;
+      if (idToDelete) await deleteRecord(idToDelete, token);
 
       // Create new record with corrected time
-      await createRecord(newRecord, token)
+      await createRecord(newRecord, token);
 
-      onToast('時刻を修正しました', 'success')
-      onSaved()
+      onToast("時刻を修正しました", "success");
+      onSaved();
     } catch {
-      onToast('保存に失敗しました', 'danger')
+      onToast("保存に失敗しました", "danger");
     } finally {
-      setSaving(false)
+      setSaving(false);
     }
-  }
+  };
 
   return (
     <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
-      <DialogTitle sx={{ fontSize: '1rem' }}>
-        {period.label} — {isEnd ? '終了時刻' : '開始時刻'}の修正
-        <IconButton onClick={onClose} size="small" sx={{ position: 'absolute', right: 8, top: 8 }}>
+      <DialogTitle sx={{ fontSize: "1rem" }}>
+        {period.label} — {isEnd ? "終了時刻" : "開始時刻"}の修正
+        <IconButton
+          onClick={onClose}
+          size="small"
+          sx={{ position: "absolute", right: 8, top: 8 }}
+        >
           ×
         </IconButton>
       </DialogTitle>
       <DialogContent>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-          {isEnd ? '終了' : '開始'}時刻を変更してください
+          {isEnd ? "終了" : "開始"}時刻を変更してください
         </Typography>
         <input
           type="datetime-local"
@@ -293,146 +366,187 @@ function EditModal({ target, token, onSaved, onClose, onToast }: EditModalProps)
         />
       </DialogContent>
       <DialogActions>
-        <button className="btn btn-outline-secondary btn-sm" onClick={onClose} disabled={saving}>
+        <button
+          className="btn btn-outline-secondary btn-sm"
+          onClick={onClose}
+          disabled={saving}
+        >
           キャンセル
         </button>
-        <button className="btn btn-warning btn-sm" onClick={handleSave} disabled={saving || !value}>
-          {saving ? <span className="spinner-border spinner-border-sm" /> : '保存'}
+        <button
+          className="btn btn-warning btn-sm"
+          onClick={handleSave}
+          disabled={saving || !value}
+        >
+          {saving ? (
+            <span className="spinner-border spinner-border-sm" />
+          ) : (
+            "保存"
+          )}
         </button>
       </DialogActions>
     </Dialog>
-  )
+  );
 }
 
 // ── period action modal (choose start/end) ────────────────────────────────────
 
 interface PeriodActionModalProps {
-  period: StatusPeriod
-  onEdit: (editType: 'start' | 'end') => void
-  onClose: () => void
+  period: StatusPeriod;
+  onEdit: (editType: "start" | "end") => void;
+  onClose: () => void;
 }
 
-function PeriodActionModal({ period, onEdit, onClose }: PeriodActionModalProps) {
+function PeriodActionModal({
+  period,
+  onEdit,
+  onClose,
+}: PeriodActionModalProps) {
   const fmt = (d: Date) =>
-    d.toLocaleString('ja-JP', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+    d.toLocaleString("ja-JP", {
+      month: "numeric",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
 
   return (
     <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
-      <DialogTitle sx={{ fontSize: '1rem' }}>
+      <DialogTitle sx={{ fontSize: "1rem" }}>
         {period.label}
-        <IconButton onClick={onClose} size="small" sx={{ position: 'absolute', right: 8, top: 8 }}>
+        <IconButton
+          onClick={onClose}
+          size="small"
+          sx={{ position: "absolute", right: 8, top: 8 }}
+        >
           ×
         </IconButton>
       </DialogTitle>
       <DialogContent>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          <div style={{ fontSize: '0.85rem', color: '#495057' }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <div style={{ fontSize: "0.85rem", color: "#495057" }}>
             <span>開始: </span>
             <strong>{fmt(period.startAt)}</strong>
           </div>
-          <div style={{ fontSize: '0.85rem', color: '#495057' }}>
+          <div style={{ fontSize: "0.85rem", color: "#495057" }}>
             <span>終了: </span>
-            <strong>{period.endAt ? fmt(period.endAt) : '（継続中）'}</strong>
+            <strong>{period.endAt ? fmt(period.endAt) : "（継続中）"}</strong>
           </div>
         </div>
       </DialogContent>
-      <DialogActions sx={{ flexDirection: 'column', gap: 1, px: 2, pb: 2 }}>
+      <DialogActions sx={{ flexDirection: "column", gap: 1, px: 2, pb: 2 }}>
         <button
           className="btn btn-outline-warning btn-sm w-100"
-          onClick={() => onEdit('start')}
+          onClick={() => onEdit("start")}
         >
           開始時刻を修正
         </button>
         <button
           className="btn btn-outline-secondary btn-sm w-100"
-          onClick={() => onEdit('end')}
+          onClick={() => onEdit("end")}
         >
-          {period.endAt ? '終了時刻を修正' : '終了時刻を設定（OFF忘れ）'}
+          {period.endAt ? "終了時刻を修正" : "終了時刻を設定（OFF忘れ）"}
         </button>
       </DialogActions>
     </Dialog>
-  )
+  );
 }
 
 // ── main component ────────────────────────────────────────────────────────────
 
 const BUILTIN_STATUS_ITEMS = [
-  { item_id: 'headache',    label: '頭痛' },
-  { item_id: 'stomachache', label: '腹痛' },
-  { item_id: 'sleepy',      label: '眠い' },
-  { item_id: 'working',     label: '勤務中' },
-]
+  { item_id: "headache", label: "頭痛" },
+  { item_id: "stomachache", label: "腹痛" },
+  { item_id: "sleepy", label: "眠い" },
+  { item_id: "working", label: "勤務中" },
+];
 
-type ViewType = '12h' | '24h' | '1week'
+type ViewType = "12h" | "24h" | "1week";
 
 interface Props {
-  open: boolean
-  onClose: () => void
-  token: string
-  statusItems: ItemConfig[]
-  onToast: (message: string, variant: ToastVariant) => void
+  open: boolean;
+  onClose: () => void;
+  token: string;
+  statusItems: ItemConfig[];
+  onToast: (message: string, variant: ToastVariant) => void;
 }
 
-export default function StatusManagerModal({ open, onClose, token, statusItems, onToast }: Props) {
-  const [view, setView] = useState<ViewType>('12h')
-  const [records, setRecords] = useState<LatestRecord[]>([])
-  const [loading, setLoading] = useState(false)
-  const [weekTab, setWeekTab] = useState(0)
-  const [selectedPeriod, setSelectedPeriod] = useState<StatusPeriod | null>(null)
-  const [editTarget, setEditTarget] = useState<EditTarget | null>(null)
+export default function StatusManagerModal({
+  open,
+  onClose,
+  token,
+  statusItems,
+  onToast,
+}: Props) {
+  const [view, setView] = useState<ViewType>("12h");
+  const [records, setRecords] = useState<LatestRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [weekTab, setWeekTab] = useState(0);
+  const [selectedPeriod, setSelectedPeriod] = useState<StatusPeriod | null>(
+    null,
+  );
+  const [editTarget, setEditTarget] = useState<EditTarget | null>(null);
 
   const allStatusLabels = [
     ...BUILTIN_STATUS_ITEMS,
     ...statusItems.map((s) => ({ item_id: s.item_id, label: s.label })),
-  ]
+  ];
 
-  const today = toYMD(new Date())
+  const today = toYMD(new Date());
 
   const fetchRecords = useCallback(async () => {
-    setLoading(true)
+    setLoading(true);
     try {
-      const dateFrom = view === '1week' ? toYMD(addDays(new Date(), -7)) : today
-      const { records: recs } = await getStatusRecords(token, dateFrom, today)
-      setRecords(recs)
-    } catch {
-      onToast('ステータス履歴の取得に失敗しました', 'danger')
+      const dateFrom =
+        view === "1week" ? toYMD(addDays(new Date(), -7)) : today;
+      const { records: recs } = await getStatusRecords(token, dateFrom, today);
+      setRecords(recs);
+    } catch (e) {
+      console.error("fetchRecords failed:", e);
+      onToast("ステータス履歴の取得に失敗しました", "danger");
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }, [token, view, today, onToast])
+  }, [token, view, today, onToast]);
 
   useEffect(() => {
-    if (open) fetchRecords()
-  }, [open, fetchRecords])
+    if (open) fetchRecords();
+  }, [open, fetchRecords]);
 
-  const periods = parseStatusPeriods(records)
+  const periods = parseStatusPeriods(records);
 
-  const axisStartH = view === '12h' ? 8 : 0
-  const axisEndH = 24
+  const axisStartH = view === "12h" ? 8 : 0;
+  const axisEndH = 24;
 
   // Last 7 days for 1週間 view
-  const last7Days = Array.from({ length: 7 }, (_, i) => toYMD(addDays(new Date(), -6 + i)))
+  const last7Days = Array.from({ length: 7 }, (_, i) =>
+    toYMD(addDays(new Date(), -6 + i)),
+  );
 
-  const handleBarClick = (p: StatusPeriod) => setSelectedPeriod(p)
+  const handleBarClick = (p: StatusPeriod) => setSelectedPeriod(p);
 
-  const handleEditType = (editType: 'start' | 'end') => {
-    if (!selectedPeriod) return
-    setEditTarget({ period: selectedPeriod, editType })
-    setSelectedPeriod(null)
-  }
+  const handleEditType = (editType: "start" | "end") => {
+    if (!selectedPeriod) return;
+    setEditTarget({ period: selectedPeriod, editType });
+    setSelectedPeriod(null);
+  };
 
   const handleSaved = () => {
-    setEditTarget(null)
-    fetchRecords()
-    onToast('ガントチャートを更新しました', 'success')
-  }
+    setEditTarget(null);
+    fetchRecords();
+    onToast("ガントチャートを更新しました", "success");
+  };
 
   return (
     <>
       <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
         <DialogTitle sx={{ pb: 1 }}>
           ステータスの管理
-          <IconButton onClick={onClose} size="small" sx={{ position: 'absolute', right: 8, top: 8 }}>
+          <IconButton
+            onClick={onClose}
+            size="small"
+            sx={{ position: "absolute", right: 8, top: 8 }}
+          >
             ×
           </IconButton>
         </DialogTitle>
@@ -440,14 +554,18 @@ export default function StatusManagerModal({ open, onClose, token, statusItems, 
         <DialogContent sx={{ pt: 0 }}>
           {/* View toggle */}
           <div className="btn-group mb-3" role="group">
-            {(['12h', '24h', '1week'] as const).map((v) => (
+            {(["12h", "24h", "1week"] as const).map((v) => (
               <button
                 key={v}
                 type="button"
-                className={`btn btn-sm ${view === v ? 'btn-warning' : 'btn-outline-secondary'}`}
+                className={`btn btn-sm ${view === v ? "btn-warning" : "btn-outline-secondary"}`}
                 onClick={() => setView(v)}
               >
-                {v === '12h' ? '12h（08-24）' : v === '24h' ? '24h（00-24）' : '1週間'}
+                {v === "12h"
+                  ? "12h（08-24）"
+                  : v === "24h"
+                    ? "24h（00-24）"
+                    : "1週間"}
               </button>
             ))}
           </div>
@@ -455,9 +573,11 @@ export default function StatusManagerModal({ open, onClose, token, statusItems, 
           {loading ? (
             <div className="text-center py-4">
               <span className="spinner-border spinner-border-sm text-warning" />
-              <span className="ms-2 text-muted" style={{ fontSize: '0.85rem' }}>読み込み中...</span>
+              <span className="ms-2 text-muted" style={{ fontSize: "0.85rem" }}>
+                読み込み中...
+              </span>
             </div>
-          ) : view !== '1week' ? (
+          ) : view !== "1week" ? (
             /* 12h / 24h view */
             <GanttChart
               periods={periods}
@@ -478,28 +598,44 @@ export default function StatusManagerModal({ open, onClose, token, statusItems, 
                 sx={{ mb: 2, minHeight: 36 }}
               >
                 {allStatusLabels.map(({ label }, i) => (
-                  <Tab key={i} label={label} sx={{ minHeight: 36, fontSize: '0.8rem', py: 0.5 }} />
+                  <Tab
+                    key={i}
+                    label={label}
+                    sx={{ minHeight: 36, fontSize: "0.8rem", py: 0.5 }}
+                  />
                 ))}
               </Tabs>
 
               {allStatusLabels[weekTab] && (
                 <div>
                   {/* Time axis */}
-                  <div style={{ display: 'flex', paddingLeft: 72, marginBottom: 4 }}>
+                  <div
+                    style={{
+                      display: "flex",
+                      paddingLeft: 72,
+                      marginBottom: 4,
+                    }}
+                  >
                     {AXIS_HOURS.filter((h) => h >= 8).map((h, i, arr) => (
                       <div
                         key={h}
-                        style={{ flex: i < arr.length - 1 ? 1 : 0, fontSize: '0.65rem', color: '#868e96' }}
+                        style={{
+                          flex: i < arr.length - 1 ? 1 : 0,
+                          fontSize: "0.65rem",
+                          color: "#868e96",
+                        }}
                       >
-                        {`${String(h).padStart(2, '0')}:00`}
+                        {`${String(h).padStart(2, "0")}:00`}
                       </div>
                     ))}
                   </div>
                   {last7Days.map((dateStr) => (
                     <GanttRow
                       key={dateStr}
-                      label={dateStr.slice(5)}  // "MM-DD"
-                      periods={periods.filter((p) => p.item_id === allStatusLabels[weekTab].item_id)}
+                      label={dateStr.slice(5)} // "MM-DD"
+                      periods={periods.filter(
+                        (p) => p.item_id === allStatusLabels[weekTab].item_id,
+                      )}
                       dateStr={dateStr}
                       axisStartH={8}
                       axisEndH={24}
@@ -537,5 +673,5 @@ export default function StatusManagerModal({ open, onClose, token, statusItems, 
         />
       )}
     </>
-  )
+  );
 }

--- a/lambda/get_latest/handler.py
+++ b/lambda/get_latest/handler.py
@@ -59,9 +59,9 @@ def lambda_handler(event, context):
     if record_type:
         conditions.append(f"record_type = '{record_type}'")
     if date_from:
-        conditions.append(f"dt >= '{date_from}'")
+        conditions.append(f"DATE(recorded_at) >= DATE '{date_from}'")
     if date_to:
-        conditions.append(f"dt <= '{date_to}'")
+        conditions.append(f"DATE(recorded_at) <= DATE '{date_to}'")
 
     where_clause = " AND ".join(conditions)
 

--- a/lambda/get_latest/test_handler.py
+++ b/lambda/get_latest/test_handler.py
@@ -152,7 +152,7 @@ def test_invalid_record_type_returns_400():
 
 @patch("handler.athena")
 def test_date_from_filter(mock_athena):
-    """date_from adds dt >= '...' to WHERE clause"""
+    """date_from adds DATE(recorded_at) >= DATE '...' to WHERE clause"""
     mock_athena.start_query_execution.return_value = {"QueryExecutionId": "qid-df"}
     mock_athena.get_query_execution.return_value = {
         "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
@@ -165,12 +165,12 @@ def test_date_from_filter(mock_athena):
     result = handler.lambda_handler(_auth_event_params(date_from="2024-01-01"), None)
     assert result["statusCode"] == 200
     qs = mock_athena.start_query_execution.call_args[1]["QueryString"]
-    assert "dt >= '2024-01-01'" in qs
+    assert "DATE(recorded_at) >= DATE '2024-01-01'" in qs
 
 
 @patch("handler.athena")
 def test_date_to_filter(mock_athena):
-    """date_to adds dt <= '...' to WHERE clause"""
+    """date_to adds DATE(recorded_at) <= DATE '...' to WHERE clause"""
     mock_athena.start_query_execution.return_value = {"QueryExecutionId": "qid-dt"}
     mock_athena.get_query_execution.return_value = {
         "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
@@ -183,7 +183,7 @@ def test_date_to_filter(mock_athena):
     result = handler.lambda_handler(_auth_event_params(date_to="2024-01-31"), None)
     assert result["statusCode"] == 200
     qs = mock_athena.start_query_execution.call_args[1]["QueryString"]
-    assert "dt <= '2024-01-31'" in qs
+    assert "DATE(recorded_at) <= DATE '2024-01-31'" in qs
 
 
 def test_invalid_date_from_returns_400():
@@ -214,3 +214,37 @@ def test_limit_cap_increased_to_1000(mock_athena):
     assert result["statusCode"] == 200
     qs = mock_athena.start_query_execution.call_args[1]["QueryString"]
     assert "LIMIT 1000" in qs
+
+
+@patch("handler.athena")
+def test_get_status_records_combined(mock_athena):
+    """getStatusRecords pattern: record_type=status + date_from + date_to uses DATE(recorded_at)"""
+    mock_athena.start_query_execution.return_value = {"QueryExecutionId": "qid-sr"}
+    mock_athena.get_query_execution.return_value = {
+        "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
+    }
+    mock_athena.get_query_results.return_value = {
+        "ResultSet": {
+            "Rows": [
+                {"Data": [{"VarCharValue": "id"}, {"VarCharValue": "record_type"}, {"VarCharValue": "recorded_at"}]},
+                {"Data": [{"VarCharValue": "abc-123"}, {"VarCharValue": "status"}, {"VarCharValue": "2026-04-01T10:00:00Z"}]},
+            ]
+        }
+    }
+
+    import handler
+    result = handler.lambda_handler(
+        _auth_event_params(record_type="status", date_from="2026-04-01", date_to="2026-04-11", limit="500"),
+        None,
+    )
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert len(body["records"]) == 1
+
+    qs = mock_athena.start_query_execution.call_args[1]["QueryString"]
+    assert "record_type = 'status'" in qs
+    assert "DATE(recorded_at) >= DATE '2026-04-01'" in qs
+    assert "DATE(recorded_at) <= DATE '2026-04-11'" in qs
+    # dt column must NOT appear in the query
+    assert "dt >=" not in qs
+    assert "dt <=" not in qs


### PR DESCRIPTION
## 関連イシュー
Closes #146

## 根本原因

`get_latest/handler.py` の date_from / date_to フィルタが `dt` カラムを参照していたが、
`dt` は Iceberg スキーマ（Glue カタログ）に存在しない。
PR #23 で SELECT から `dt` を除去した際に WHERE 句が修正されなかったことが原因。

```sql
-- Before（COLUMN_NOT_FOUND で Athena FAILED）
WHERE dt >= '2024-01-01' AND dt <= '2024-01-31'

-- After（recorded_at は timestamp 型として存在する）
WHERE DATE(recorded_at) >= DATE '2024-01-01' AND DATE(recorded_at) <= DATE '2024-01-31'
```

## 変更内容
- `lambda/get_latest/handler.py`: `dt >= / <=` を `DATE(recorded_at) >= / <=` に変更
- `lambda/get_latest/test_handler.py`: 既存 date_from / date_to テストのアサーションを更新。`getStatusRecords` の複合パラメータ（record_type=status + date_from + date_to）テストを追加
- `frontend/src/components/StatusManagerModal.tsx`: catch ブロックに `console.error` を追加

## テスト確認
- [x] pytest lambda/ -v → 100 passed
- [x] npx tsc --noEmit → エラーなし

## レビュー観点
- `DATE(recorded_at)` は Athena (Presto) で timestamp → date へのキャストとして動作する
- `dt` カラムへの参照がクエリ文字列に残っていないことを `test_get_status_records_combined` で回帰テスト