### PR TITLE
feat(frontend): 傾向グラフに7日ビューを追加し集計ロジックを分離

### DIFF
--- a/frontend/src/__tests__/trendUtils.test.ts
+++ b/frontend/src/__tests__/trendUtils.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import { computeDailyAvg, computeWeekdayAvg } from "../utils/trendUtils";
+import type { LatestRecord } from "../types";
+
+function makeRecord(overrides: Partial<LatestRecord> = {}): LatestRecord {
+  return {
+    id: "test-id",
+    record_type: "daily",
+    fatigue_score: "",
+    mood_score: "",
+    motivation_score: "",
+    concentration_score: "",
+    flags: "0",
+    note: "",
+    recorded_at: "2026-04-10 10:00:00",
+    timezone: "Asia/Tokyo",
+    device_id: "",
+    app_version: "1.0.0",
+    custom_fields: "[]",
+    written_at: "2026-04-10 10:00:00",
+    ...overrides,
+  };
+}
+
+describe("computeDailyAvg", () => {
+  it("returns empty array when no records", () => {
+    const result = computeDailyAvg([], 30);
+    expect(result).toHaveLength(0);
+  });
+
+  it("computes daily averages for records within the period", () => {
+    const now = new Date();
+    const yesterday = new Date(now);
+    yesterday.setDate(now.getDate() - 1);
+    const yStr = yesterday.toISOString().replace("T", " ").slice(0, 19);
+
+    const records = [
+      makeRecord({
+        fatigue_score: "60",
+        mood_score: "70",
+        motivation_score: "80",
+        recorded_at: yStr,
+      }),
+      makeRecord({
+        fatigue_score: "80",
+        mood_score: "50",
+        motivation_score: "60",
+        recorded_at: yStr,
+      }),
+    ];
+    const result = computeDailyAvg(records, 30);
+    expect(result).toHaveLength(1);
+    expect(result[0].fatigue).toBe(70); // avg(60,80)
+    expect(result[0].mood).toBe(60); // avg(70,50)
+    expect(result[0].motivation).toBe(70); // avg(80,60)
+  });
+
+  it("excludes records older than the specified days", () => {
+    const now = new Date();
+    const old = new Date(now);
+    old.setDate(now.getDate() - 10);
+    const oldStr = old.toISOString().replace("T", " ").slice(0, 19);
+
+    const records = [makeRecord({ fatigue_score: "50", recorded_at: oldStr })];
+    // 7-day window should exclude a 10-day-old record
+    const result = computeDailyAvg(records, 7);
+    expect(result).toHaveLength(0);
+  });
+
+  it("includes records within 7-day window", () => {
+    const now = new Date();
+    const fiveDaysAgo = new Date(now);
+    fiveDaysAgo.setDate(now.getDate() - 5);
+    const str = fiveDaysAgo.toISOString().replace("T", " ").slice(0, 19);
+
+    const records = [makeRecord({ fatigue_score: "50", recorded_at: str })];
+    const result = computeDailyAvg(records, 7);
+    expect(result).toHaveLength(1);
+    expect(result[0].fatigue).toBe(50);
+  });
+
+  it("excludes non-daily record_types", () => {
+    const now = new Date();
+    const str = now.toISOString().replace("T", " ").slice(0, 19);
+
+    const records = [
+      makeRecord({
+        record_type: "event",
+        fatigue_score: "50",
+        recorded_at: str,
+      }),
+      makeRecord({
+        record_type: "status",
+        fatigue_score: "70",
+        recorded_at: str,
+      }),
+    ];
+    const result = computeDailyAvg(records, 30);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns null for metrics with no valid data", () => {
+    const now = new Date();
+    const str = now.toISOString().replace("T", " ").slice(0, 19);
+
+    const records = [
+      makeRecord({
+        fatigue_score: "60",
+        mood_score: "",
+        motivation_score: "",
+        recorded_at: str,
+      }),
+    ];
+    const result = computeDailyAvg(records, 30);
+    expect(result).toHaveLength(1);
+    expect(result[0].fatigue).toBe(60);
+    expect(result[0].mood).toBeNull();
+    expect(result[0].motivation).toBeNull();
+  });
+
+  it("returns rows sorted by date ascending", () => {
+    const now = new Date();
+    const d1 = new Date(now);
+    d1.setDate(now.getDate() - 5);
+    const d2 = new Date(now);
+    d2.setDate(now.getDate() - 2);
+    const str1 = d1.toISOString().replace("T", " ").slice(0, 19);
+    const str2 = d2.toISOString().replace("T", " ").slice(0, 19);
+
+    const records = [
+      makeRecord({ fatigue_score: "40", recorded_at: str2 }),
+      makeRecord({ fatigue_score: "80", recorded_at: str1 }),
+    ];
+    const result = computeDailyAvg(records, 30);
+    expect(result[0].fatigue).toBe(80); // older date first
+    expect(result[1].fatigue).toBe(40);
+  });
+});
+
+describe("computeWeekdayAvg", () => {
+  it("returns 7 entries (Mon–Sun) always", () => {
+    const result = computeWeekdayAvg([], 30);
+    expect(result).toHaveLength(7);
+    expect(result[0].label).toBe("月");
+    expect(result[6].label).toBe("日");
+  });
+
+  it("groups records by day of week correctly", () => {
+    // 2026-04-13 is a Monday (月).
+    // Use 10:00 and 12:00 UTC so both are still Monday in JST (UTC+9: 19:00 and 21:00).
+    const records = [
+      makeRecord({ fatigue_score: "60", recorded_at: "2026-04-13 10:00:00" }),
+      makeRecord({ fatigue_score: "80", recorded_at: "2026-04-13 12:00:00" }),
+    ];
+    const result = computeWeekdayAvg(records, 30);
+    expect(result[0].label).toBe("月");
+    expect(result[0].fatigue).toBe(70); // avg(60,80)
+  });
+
+  it("returns null for weekdays with no data", () => {
+    // Only Monday records
+    const records = [
+      makeRecord({ fatigue_score: "50", recorded_at: "2026-04-13 10:00:00" }),
+    ];
+    const result = computeWeekdayAvg(records, 30);
+    expect(result[0].fatigue).toBe(50); // 月
+    expect(result[1].fatigue).toBeNull(); // 火
+  });
+
+  it("respects the days cutoff", () => {
+    // Record 60 days ago — excluded from 30-day window
+    const now = new Date();
+    const old = new Date(now);
+    old.setDate(now.getDate() - 60);
+    const oldStr = old.toISOString().replace("T", " ").slice(0, 19);
+
+    const records = [makeRecord({ fatigue_score: "99", recorded_at: oldStr })];
+    const result = computeWeekdayAvg(records, 30);
+    const allNull = result.every((r) => r.fatigue === null);
+    expect(allNull).toBe(true);
+  });
+});

--- a/frontend/src/utils/trendUtils.ts
+++ b/frontend/src/utils/trendUtils.ts
@@ -1,0 +1,135 @@
+import type { LatestRecord } from "../types";
+
+export interface DailyAvg {
+  date: string; // MM-DD
+  fatigue: number | null;
+  mood: number | null;
+  motivation: number | null;
+  concentration: number | null;
+}
+
+export interface WeekdayAvg {
+  label: string; // 月〜日
+  fatigue: number | null;
+  mood: number | null;
+  motivation: number | null;
+  concentration: number | null;
+}
+
+const WEEKDAY_LABELS = ["月", "火", "水", "木", "金", "土", "日"];
+
+function parseRecordDate(recorded_at: string): Date {
+  // Athena returns "YYYY-MM-DD HH:MM:SS" (UTC) or ISO 8601
+  if (recorded_at.includes("T")) {
+    return new Date(recorded_at);
+  }
+  return new Date(recorded_at.replace(" ", "T") + "Z");
+}
+
+function avg(arr: number[]): number | null {
+  if (arr.length === 0) return null;
+  return Math.round(arr.reduce((a, b) => a + b, 0) / arr.length);
+}
+
+export function computeDailyAvg(
+  records: LatestRecord[],
+  days: number,
+): DailyAvg[] {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+
+  type Bucket = {
+    fatigue: number[];
+    mood: number[];
+    motivation: number[];
+    concentration: number[];
+  };
+  const byDate: Record<string, Bucket> = {};
+
+  for (const r of records) {
+    if (r.record_type !== "daily") continue;
+    const d = parseRecordDate(r.recorded_at);
+    if (d < cutoff) continue;
+
+    // Local date string YYYY-MM-DD using local timezone
+    const key = [
+      d.getFullYear(),
+      String(d.getMonth() + 1).padStart(2, "0"),
+      String(d.getDate()).padStart(2, "0"),
+    ].join("-");
+
+    if (!byDate[key])
+      byDate[key] = {
+        fatigue: [],
+        mood: [],
+        motivation: [],
+        concentration: [],
+      };
+    const f = parseFloat(r.fatigue_score);
+    const m = parseFloat(r.mood_score);
+    const mv = parseFloat(r.motivation_score);
+    const c = parseFloat(r.concentration_score);
+    if (!isNaN(f)) byDate[key].fatigue.push(f);
+    if (!isNaN(m)) byDate[key].mood.push(m);
+    if (!isNaN(mv)) byDate[key].motivation.push(mv);
+    if (!isNaN(c)) byDate[key].concentration.push(c);
+  }
+
+  return Object.entries(byDate)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, bucket]) => ({
+      date: date.slice(5), // MM-DD
+      fatigue: avg(bucket.fatigue),
+      mood: avg(bucket.mood),
+      motivation: avg(bucket.motivation),
+      concentration: avg(bucket.concentration),
+    }));
+}
+
+export function computeWeekdayAvg(
+  records: LatestRecord[],
+  days: number,
+): WeekdayAvg[] {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+
+  type Bucket = {
+    fatigue: number[];
+    mood: number[];
+    motivation: number[];
+    concentration: number[];
+  };
+  const byWeekday: Bucket[] = Array.from({ length: 7 }, () => ({
+    fatigue: [],
+    mood: [],
+    motivation: [],
+    concentration: [],
+  }));
+
+  for (const r of records) {
+    if (r.record_type !== "daily") continue;
+    const d = parseRecordDate(r.recorded_at);
+    if (d < cutoff) continue;
+
+    // JS: 0=日, 1=月, ..., 6=土 → 月始まりに変換 (月=0, ..., 日=6)
+    const jsDay = d.getDay();
+    const monFirst = jsDay === 0 ? 6 : jsDay - 1;
+
+    const f = parseFloat(r.fatigue_score);
+    const m = parseFloat(r.mood_score);
+    const mv = parseFloat(r.motivation_score);
+    const c = parseFloat(r.concentration_score);
+    if (!isNaN(f)) byWeekday[monFirst].fatigue.push(f);
+    if (!isNaN(m)) byWeekday[monFirst].mood.push(m);
+    if (!isNaN(mv)) byWeekday[monFirst].motivation.push(mv);
+    if (!isNaN(c)) byWeekday[monFirst].concentration.push(c);
+  }
+
+  return WEEKDAY_LABELS.map((label, i) => ({
+    label,
+    fatigue: avg(byWeekday[i].fatigue),
+    mood: avg(byWeekday[i].mood),
+    motivation: avg(byWeekday[i].motivation),
+    concentration: avg(byWeekday[i].concentration),
+  }));
+}


### PR DESCRIPTION
## 関連イシュー
Closes #150

## 変更内容
- トレンドタブの期間セレクタに **7日** を追加（7日 / 30日 / 90日）
- 日次平均（`computeDailyAvg`）・曜日別平均（`computeWeekdayAvg`）の集計ロジックを `frontend/src/utils/trendUtils.ts` に抽出
- `DashboardPage` はユーティリティ関数を呼び出す形に変更（重複コード削除）
- インラインの `DailyAvg` 型定義を削除し、`trendUtils` からインポート

## 完了条件の確認
- [x] 月次ビュー（30日スコア推移グラフ）: 既存の `trendAggMode=daily` + 30日選択で対応
- [x] 週次ビュー（曜日ごとの平均スコア）: 既存の `trendAggMode=weekday` で対応
- [x] ビュー切替タブ（**7日** / 30日 / 90日）: 今回追加
- [x] スコア種別の表示切替（疲労感 / 気分 / やる気）: 既存の `MetricSelector` で対応

## テスト確認
- [x] `npx vitest run src/__tests__/` → 36 件 PASSED
- [x] `tsc --noEmit` → エラーなし
- [x] `npm run build` → 成功

## レビュー観点
- `trendUtils.ts` の `parseRecordDate` は Athena の `YYYY-MM-DD HH:MM:SS`（UTC 文字列）と ISO 8601 の両方を処理
- テストの日時は JST タイムゾーンでも日付をまたがない UTC 時刻（10:00〜12:00）を使用