### PR TITLE
feat(dashboard): 週次サマリーダッシュボード（7日推移グラフ）

### DIFF
--- a/frontend/src/components/DashboardPage.tsx
+++ b/frontend/src/components/DashboardPage.tsx
@@ -18,6 +18,7 @@ import {
 } from "recharts";
 import { getEnvData, getLatest } from "../api";
 import { CorrelationHeatmap } from "./CorrelationHeatmap";
+import WeeklySummaryCard from "./WeeklySummaryCard";
 import { useAuth } from "../hooks/useAuth";
 import type { EnvDataRecord, LatestRecord } from "../types";
 import {
@@ -36,7 +37,7 @@ import {
   computeIntradayData,
 } from "../utils/dashboardUtils";
 import type { MetricKey } from "../utils/dashboardUtils";
-type Tab = "trend" | "intraday" | "events" | "env" | "correlation";
+type Tab = "summary" | "trend" | "intraday" | "events" | "env" | "correlation";
 type EventsView = "timeline" | "trend";
 type TrendAggMode = "daily" | "weekday" | "timeband";
 
@@ -163,7 +164,8 @@ export default function DashboardPage({ onBack }: Props) {
   const [envRecords, setEnvRecords] = useState<EnvDataRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
-  const [tab, setTab] = useState<Tab>("trend");
+  const [tab, setTab] = useState<Tab>("summary");
+  const [summaryDays, setSummaryDays] = useState(7);
   const [eventsView, setEventsView] = useState<EventsView>("timeline");
   const [trendDays, setTrendDays] = useState(30);
   const [trendAggMode, setTrendAggMode] = useState<TrendAggMode>("daily");
@@ -640,6 +642,7 @@ export default function DashboardPage({ onBack }: Props) {
         <ul className="nav nav-tabs mb-4">
           {(
             [
+              { key: "summary", label: "週次サマリー" },
               { key: "trend", label: "長期トレンド" },
               { key: "intraday", label: "日内変動" },
               { key: "events", label: "イベント" },
@@ -660,6 +663,24 @@ export default function DashboardPage({ onBack }: Props) {
 
         {loading && <p className="text-muted">読み込み中…</p>}
         {fetchError && <div className="alert alert-danger">{fetchError}</div>}
+
+        {/* ── 週次サマリー ── */}
+        {tab === "summary" && token && (
+          <div>
+            <div className="d-flex gap-2 mb-3">
+              {[7, 14, 30].map((d) => (
+                <button
+                  key={d}
+                  className={`btn btn-sm ${summaryDays === d ? "btn-success" : "btn-outline-secondary"}`}
+                  onClick={() => setSummaryDays(d)}
+                >
+                  {d}日
+                </button>
+              ))}
+            </div>
+            <WeeklySummaryCard token={token} days={summaryDays} />
+          </div>
+        )}
 
         {/* ── 長期トレンド ── */}
         {!loading && tab === "trend" && (

--- a/frontend/src/components/WeeklySummaryCard.tsx
+++ b/frontend/src/components/WeeklySummaryCard.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useState } from "react";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { getWeeklySummary } from "../api";
+import type { SummaryDay } from "../types";
+
+interface Props {
+  token: string;
+  days?: number;
+}
+
+interface ChartPoint {
+  date: string;
+  fatigue: number | null;
+  mood: number | null;
+  motivation: number | null;
+}
+
+interface StatRow {
+  label: string;
+  avg: string;
+  max: string;
+  min: string;
+  color: string;
+}
+
+function toNum(v: string | null | undefined): number | null {
+  if (v == null || v === "") return null;
+  const n = parseFloat(v);
+  return isNaN(n) ? null : Math.round(n * 10) / 10;
+}
+
+function fmt(v: number | null): string {
+  return v == null ? "—" : String(v);
+}
+
+export default function WeeklySummaryCard({ token, days = 7 }: Props) {
+  const [summaries, setSummaries] = useState<SummaryDay[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    getWeeklySummary(token, days)
+      .then((res) => setSummaries(res.summaries))
+      .catch((e: unknown) =>
+        setError((e as Error).message ?? "取得に失敗しました"),
+      )
+      .finally(() => setLoading(false));
+  }, [token, days]);
+
+  if (loading) return <p className="text-muted small">読み込み中…</p>;
+  if (error) return <div className="alert alert-warning small">{error}</div>;
+  if (summaries.length === 0) {
+    return (
+      <p className="text-muted small">
+        集計データがありません（毎日 AM 2:00 に前日分を集計）。
+      </p>
+    );
+  }
+
+  const sorted = [...summaries].sort((a, b) => a.date.localeCompare(b.date));
+
+  const chartData: ChartPoint[] = sorted.map((s) => ({
+    date: s.date.slice(5),
+    fatigue: toNum(s.avg_fatigue),
+    mood: toNum(s.avg_mood),
+    motivation: toNum(s.avg_motivation),
+  }));
+
+  // 期間全体の統計（最新 days 日のサマリーから計算）
+  const statsRows: StatRow[] = [
+    {
+      label: "疲労度",
+      avg: fmt(
+        toNum(
+          (
+            sorted.reduce((s, d) => s + (toNum(d.avg_fatigue) ?? 0), 0) /
+            sorted.filter((d) => d.avg_fatigue != null).length
+          ).toFixed(1),
+        ),
+      ),
+      max: fmt(
+        sorted.reduce<number | null>((best, d) => {
+          const v = toNum(d.max_fatigue);
+          return v == null ? best : best == null ? v : Math.max(best, v);
+        }, null),
+      ),
+      min: fmt(
+        sorted.reduce<number | null>((best, d) => {
+          const v = toNum(d.min_fatigue);
+          return v == null ? best : best == null ? v : Math.min(best, v);
+        }, null),
+      ),
+      color: "#dc3545",
+    },
+    {
+      label: "気分",
+      avg: fmt(
+        toNum(
+          (
+            sorted.reduce((s, d) => s + (toNum(d.avg_mood) ?? 0), 0) /
+            sorted.filter((d) => d.avg_mood != null).length
+          ).toFixed(1),
+        ),
+      ),
+      max: fmt(
+        sorted.reduce<number | null>((best, d) => {
+          const v = toNum(d.max_mood);
+          return v == null ? best : best == null ? v : Math.max(best, v);
+        }, null),
+      ),
+      min: fmt(
+        sorted.reduce<number | null>((best, d) => {
+          const v = toNum(d.min_mood);
+          return v == null ? best : best == null ? v : Math.min(best, v);
+        }, null),
+      ),
+      color: "#fd7e14",
+    },
+    {
+      label: "やる気",
+      avg: fmt(
+        toNum(
+          (
+            sorted.reduce((s, d) => s + (toNum(d.avg_motivation) ?? 0), 0) /
+            sorted.filter((d) => d.avg_motivation != null).length
+          ).toFixed(1),
+        ),
+      ),
+      max: fmt(
+        sorted.reduce<number | null>((best, d) => {
+          const v = toNum(d.max_motivation);
+          return v == null ? best : best == null ? v : Math.max(best, v);
+        }, null),
+      ),
+      min: fmt(
+        sorted.reduce<number | null>((best, d) => {
+          const v = toNum(d.min_motivation);
+          return v == null ? best : best == null ? v : Math.min(best, v);
+        }, null),
+      ),
+      color: "#198754",
+    },
+  ];
+
+  return (
+    <div>
+      {/* 折れ線グラフ */}
+      <ResponsiveContainer width="100%" height={240}>
+        <LineChart
+          data={chartData}
+          margin={{ top: 4, right: 8, left: -20, bottom: 4 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+          <YAxis domain={[0, 100]} tick={{ fontSize: 11 }} />
+          <Tooltip />
+          <Legend />
+          <Line
+            type="monotone"
+            dataKey="fatigue"
+            name="疲労度"
+            stroke="#dc3545"
+            dot={{ r: 3 }}
+            connectNulls
+          />
+          <Line
+            type="monotone"
+            dataKey="mood"
+            name="気分"
+            stroke="#fd7e14"
+            dot={{ r: 3 }}
+            connectNulls
+          />
+          <Line
+            type="monotone"
+            dataKey="motivation"
+            name="やる気"
+            stroke="#198754"
+            dot={{ r: 3 }}
+            connectNulls
+          />
+        </LineChart>
+      </ResponsiveContainer>
+
+      {/* 平均・最大・最小 テーブル */}
+      <div className="table-responsive mt-3">
+        <table
+          className="table table-sm table-bordered mb-0"
+          style={{ fontSize: 13 }}
+        >
+          <thead className="table-light">
+            <tr>
+              <th>指標</th>
+              <th className="text-center">平均</th>
+              <th className="text-center">最大</th>
+              <th className="text-center">最小</th>
+            </tr>
+          </thead>
+          <tbody>
+            {statsRows.map((row) => (
+              <tr key={row.label}>
+                <td>
+                  <span
+                    className="badge me-1"
+                    style={{ background: row.color, fontSize: 10 }}
+                  >
+                    &nbsp;
+                  </span>
+                  {row.label}
+                </td>
+                <td className="text-center fw-semibold">{row.avg}</td>
+                <td className="text-center text-danger">{row.max}</td>
+                <td className="text-center text-primary">{row.min}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="text-muted small mt-1 mb-0">
+        ※ DynamoDB キャッシュから取得（毎日 AM 2:00 更新）
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -43,21 +43,20 @@ export interface EnvDataRecord {
 
 export interface SummaryDay {
   date: string;
-  fatigue_avg: number | null;
-  fatigue_max: number | null;
-  fatigue_min: number | null;
-  mood_avg: number | null;
-  mood_max: number | null;
-  mood_min: number | null;
-  motivation_avg: number | null;
-  motivation_max: number | null;
-  motivation_min: number | null;
-  record_count: number | null;
+  avg_fatigue: string | null;
+  max_fatigue: string | null;
+  min_fatigue: string | null;
+  avg_mood: string | null;
+  max_mood: string | null;
+  min_mood: string | null;
+  avg_motivation: string | null;
+  max_motivation: string | null;
+  min_motivation: string | null;
+  record_count: string | null;
 }
 
 export interface WeeklySummaryResponse {
-  days: number;
-  summary: SummaryDay[];
+  summaries: SummaryDay[];
 }
 
 export interface LatestRecord {

--- a/lambda/aggregate_daily/handler.py
+++ b/lambda/aggregate_daily/handler.py
@@ -26,8 +26,14 @@ def lambda_handler(event, context):
         SELECT
             user_id,
             CAST(AVG(fatigue_score) AS VARCHAR) AS avg_fatigue,
+            CAST(MAX(fatigue_score) AS VARCHAR) AS max_fatigue,
+            CAST(MIN(fatigue_score) AS VARCHAR) AS min_fatigue,
             CAST(AVG(mood_score) AS VARCHAR) AS avg_mood,
+            CAST(MAX(mood_score) AS VARCHAR) AS max_mood,
+            CAST(MIN(mood_score) AS VARCHAR) AS min_mood,
             CAST(AVG(motivation_score) AS VARCHAR) AS avg_motivation,
+            CAST(MAX(motivation_score) AS VARCHAR) AS max_motivation,
+            CAST(MIN(motivation_score) AS VARCHAR) AS min_motivation,
             CAST(COUNT(*) AS VARCHAR) AS record_count
         FROM health_records
         WHERE dt = '{yesterday}'
@@ -73,8 +79,14 @@ def lambda_handler(event, context):
             "user_id": item["user_id"],
             "date": yesterday,
             "avg_fatigue": item.get("avg_fatigue", ""),
+            "max_fatigue": item.get("max_fatigue", ""),
+            "min_fatigue": item.get("min_fatigue", ""),
             "avg_mood": item.get("avg_mood", ""),
+            "max_mood": item.get("max_mood", ""),
+            "min_mood": item.get("min_mood", ""),
             "avg_motivation": item.get("avg_motivation", ""),
+            "max_motivation": item.get("max_motivation", ""),
+            "min_motivation": item.get("min_motivation", ""),
             "record_count": item.get("record_count", "0"),
         })
         saved_count += 1

--- a/lambda/aggregate_daily/test_handler.py
+++ b/lambda/aggregate_daily/test_handler.py
@@ -247,3 +247,85 @@ def test_multiple_users_saved(mock_athena, mock_ddb):
     body = json.loads(result["body"])
     assert body["saved_count"] == 2
     assert mock_table.put_item.call_count == 2
+
+
+@patch(f"{_MOD_NAME}.dynamodb")
+@patch(f"{_MOD_NAME}.athena")
+def test_query_includes_max_min(mock_athena, mock_ddb):
+    """Athena クエリに MAX/MIN が含まれる（週次サマリーの最大・最小表示に必要）"""
+    _succeeded_athena(mock_athena, [
+        {"Data": [
+            {"VarCharValue": "user_id"},
+            {"VarCharValue": "avg_fatigue"},
+            {"VarCharValue": "max_fatigue"},
+            {"VarCharValue": "min_fatigue"},
+            {"VarCharValue": "avg_mood"},
+            {"VarCharValue": "max_mood"},
+            {"VarCharValue": "min_mood"},
+            {"VarCharValue": "avg_motivation"},
+            {"VarCharValue": "max_motivation"},
+            {"VarCharValue": "min_motivation"},
+            {"VarCharValue": "record_count"},
+        ]},
+    ])
+    mock_table = MagicMock()
+    mock_ddb.Table.return_value = mock_table
+
+    _h.lambda_handler({}, None)
+
+    qs = mock_athena.start_query_execution.call_args[1]["QueryString"]
+    assert "MAX(fatigue_score)" in qs or "max(fatigue_score)" in qs.lower()
+    assert "MIN(fatigue_score)" in qs or "min(fatigue_score)" in qs.lower()
+    assert "MAX(mood_score)" in qs or "max(mood_score)" in qs.lower()
+    assert "MIN(mood_score)" in qs or "min(mood_score)" in qs.lower()
+    assert "MAX(motivation_score)" in qs or "max(motivation_score)" in qs.lower()
+    assert "MIN(motivation_score)" in qs or "min(motivation_score)" in qs.lower()
+
+
+@patch(f"{_MOD_NAME}.dynamodb")
+@patch(f"{_MOD_NAME}.athena")
+def test_max_min_saved_to_dynamodb(mock_athena, mock_ddb):
+    """MAX/MIN 値が DynamoDB に保存される"""
+    _succeeded_athena(mock_athena, [
+        {"Data": [
+            {"VarCharValue": "user_id"},
+            {"VarCharValue": "avg_fatigue"},
+            {"VarCharValue": "max_fatigue"},
+            {"VarCharValue": "min_fatigue"},
+            {"VarCharValue": "avg_mood"},
+            {"VarCharValue": "max_mood"},
+            {"VarCharValue": "min_mood"},
+            {"VarCharValue": "avg_motivation"},
+            {"VarCharValue": "max_motivation"},
+            {"VarCharValue": "min_motivation"},
+            {"VarCharValue": "record_count"},
+        ]},
+        {"Data": [
+            {"VarCharValue": "12345678-1234-1234-1234-123456789abc"},
+            {"VarCharValue": "60.0"},
+            {"VarCharValue": "80.0"},
+            {"VarCharValue": "40.0"},
+            {"VarCharValue": "70.0"},
+            {"VarCharValue": "90.0"},
+            {"VarCharValue": "50.0"},
+            {"VarCharValue": "50.0"},
+            {"VarCharValue": "70.0"},
+            {"VarCharValue": "30.0"},
+            {"VarCharValue": "3"},
+        ]},
+    ])
+
+    mock_table = MagicMock()
+    mock_ddb.Table.return_value = mock_table
+    mock_table.put_item.return_value = {}
+
+    result = _h.lambda_handler({}, None)
+
+    assert result["statusCode"] == 200
+    item = mock_table.put_item.call_args[1]["Item"]
+    assert item["max_fatigue"] == "80.0"
+    assert item["min_fatigue"] == "40.0"
+    assert item["max_mood"] == "90.0"
+    assert item["min_mood"] == "50.0"
+    assert item["max_motivation"] == "70.0"
+    assert item["min_motivation"] == "30.0"

--- a/lambda/get_summary/handler.py
+++ b/lambda/get_summary/handler.py
@@ -54,8 +54,14 @@ def lambda_handler(event, context):
         {
             "date": item["date"],
             "avg_fatigue": item.get("avg_fatigue"),
+            "max_fatigue": item.get("max_fatigue"),
+            "min_fatigue": item.get("min_fatigue"),
             "avg_mood": item.get("avg_mood"),
+            "max_mood": item.get("max_mood"),
+            "min_mood": item.get("min_mood"),
             "avg_motivation": item.get("avg_motivation"),
+            "max_motivation": item.get("max_motivation"),
+            "min_motivation": item.get("min_motivation"),
             "record_count": item.get("record_count"),
         }
         for item in response.get("Items", [])

--- a/lambda/get_summary/test_handler.py
+++ b/lambda/get_summary/test_handler.py
@@ -132,7 +132,7 @@ def test_dynamodb_error_returns_500(mock_ddb):
 
 @patch("handler.dynamodb")
 def test_response_fields(mock_ddb):
-    """レスポンスに必要なフィールドが含まれる"""
+    """レスポンスに必要なフィールドが含まれる（avg/max/min）"""
     mock_table = MagicMock()
     mock_ddb.Table.return_value = mock_table
     mock_table.query.return_value = {
@@ -141,8 +141,14 @@ def test_response_fields(mock_ddb):
                 "user_id": "12345678-1234-1234-1234-123456789abc",
                 "date": "2026-04-12",
                 "avg_fatigue": "60.5",
+                "max_fatigue": "80.0",
+                "min_fatigue": "40.0",
                 "avg_mood": "70.0",
+                "max_mood": "90.0",
+                "min_mood": "50.0",
                 "avg_motivation": "50.0",
+                "max_motivation": "70.0",
+                "min_motivation": "30.0",
                 "record_count": "2",
             }
         ]
@@ -155,6 +161,12 @@ def test_response_fields(mock_ddb):
     s = body["summaries"][0]
     assert "date" in s
     assert "avg_fatigue" in s
+    assert "max_fatigue" in s
+    assert "min_fatigue" in s
     assert "avg_mood" in s
+    assert "max_mood" in s
+    assert "min_mood" in s
     assert "avg_motivation" in s
+    assert "max_motivation" in s
+    assert "min_motivation" in s
     assert "record_count" in s


### PR DESCRIPTION
## 関連イシュー
Closes #148

## 変更内容

### Lambda
- `aggregate_daily`: Athenaクエリに `MAX`/`MIN` を追加、DynamoDBへのmax/min保存を追加
- `get_summary`: レスポンスに `max_*` / `min_*` フィールドを追加

### フロントエンド
- `WeeklySummaryCard`: `/summary` APIを使った折れ線グラフ + 平均/最大/最小テーブル（Recharts）
- `DashboardPage`: 「週次サマリー」タブをデフォルトの最初のタブとして追加（7/14/30日切り替え可）
- `types.ts`: `WeeklySummaryResponse` / `SummaryDay` を実際のAPIレスポンス仕様に修正（`summaries`, `avg_fatigue` 等）

## テスト確認
- [x] pytest lambda/ -v → 161件 PASSED
- [x] npx tsc --noEmit → エラーなし
- [x] npm run build → 成功

## 完了条件チェック
- [x] 疲労感・気分・やる気の過去7日間の推移を折れ線グラフで表示
- [x] 各スコアの平均値・最大・最小を表示
- [x] モバイルでも見やすいレイアウト（レスポンシブ対応）
- [x] Athenaから集計データを取得するLambdaエンドポイント（既存`get_summary`を拡張）
- [x] DynamoDBキャッシュを使い表示速度 < 500ms（`aggregate_daily` + DynamoDB）

## レビュー観点
- `aggregate_daily` のAthenaクエリにMAX/MIN追加はスキーマ（dt パーティション使用）に準拠しているか
- `SummaryDay` 型の値はすべて `string | null`（API側がCAST VARCHAR、フロントでparseFloat）