### PR TITLE
feat(frontend): 過去ログ閲覧・日付検索機能を追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import AuthGuard from "./components/AuthGuard";
 import DashboardPage from "./components/DashboardPage";
 import HealthForm from "./components/HealthForm";
 import type { ToastVariant } from "./components/HealthForm";
+import HistoryBrowser from "./components/HistoryBrowser";
 import ItemConfigScreen from "./components/ItemConfigScreen";
 import RecordHistory from "./components/RecordHistory";
 import { exportRecords, getLatest } from "./api";
@@ -25,6 +26,7 @@ function AppContent() {
   const [showSettings, setShowSettings] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [page, setPage] = useState(0);
+  const [historyTab, setHistoryTab] = useState<"recent" | "search">("recent");
   const [records, setRecords] = useState<LatestRecord[]>([]);
   const [toast, setToast] = useState<{
     show: boolean;
@@ -220,10 +222,28 @@ function AppContent() {
             }}
           >
             <div className="container py-3" style={{ maxWidth: "540px" }}>
-              <RecordHistory
-                records={records}
-                onDeleted={handleRecordDeleted}
-              />
+              <div className="btn-group w-100 mb-3" role="group">
+                <button
+                  className={`btn btn-sm ${historyTab === "recent" ? "btn-success" : "btn-outline-secondary"}`}
+                  onClick={() => setHistoryTab("recent")}
+                >
+                  最近の記録
+                </button>
+                <button
+                  className={`btn btn-sm ${historyTab === "search" ? "btn-success" : "btn-outline-secondary"}`}
+                  onClick={() => setHistoryTab("search")}
+                >
+                  過去ログ検索
+                </button>
+              </div>
+              {historyTab === "recent" ? (
+                <RecordHistory
+                  records={records}
+                  onDeleted={handleRecordDeleted}
+                />
+              ) : (
+                <HistoryBrowser />
+              )}
             </div>
           </div>
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -51,6 +51,23 @@ export function getLatest(
   return apiFetch(`/records/latest?limit=${limit}`, token);
 }
 
+export function getRecords(
+  token: string,
+  opts: {
+    dateFrom?: string;
+    dateTo?: string;
+    recordType?: "daily" | "event" | "status";
+    limit?: number;
+  } = {},
+): Promise<{ records: LatestRecord[] }> {
+  const params = new URLSearchParams();
+  if (opts.limit != null) params.set("limit", String(opts.limit));
+  if (opts.dateFrom) params.set("date_from", opts.dateFrom);
+  if (opts.dateTo) params.set("date_to", opts.dateTo);
+  if (opts.recordType) params.set("record_type", opts.recordType);
+  return apiFetch(`/records/latest?${params.toString()}`, token);
+}
+
 export function deleteRecord(
   id: string,
   token: string,

--- a/frontend/src/components/HistoryBrowser.tsx
+++ b/frontend/src/components/HistoryBrowser.tsx
@@ -1,0 +1,345 @@
+import { useState, useCallback } from "react";
+import { getRecords } from "../api";
+import { useAuth } from "../hooks/useAuth";
+import type { LatestRecord } from "../types";
+import { formatTime, toLocalDateStr } from "../utils/time";
+import { buildSummaryParts } from "../utils/recordSummary";
+
+const FLAG_LABELS: [number, string][] = [
+  [1, "睡眠不足"],
+  [2, "頭痛"],
+  [4, "腹痛"],
+  [8, "運動"],
+  [16, "飲酒"],
+  [32, "カフェイン"],
+];
+
+function decodeFlags(flags: string | number): string[] {
+  const n = typeof flags === "string" ? parseInt(flags, 10) : flags;
+  if (isNaN(n) || n === 0) return [];
+  return FLAG_LABELS.filter(([bit]) => (n & bit) !== 0).map(
+    ([, label]) => label,
+  );
+}
+
+function subDays(dateStr: string, days: number): string {
+  const d = new Date(`${dateStr}T00:00:00`);
+  d.setDate(d.getDate() - days);
+  return toLocalDateStr(d);
+}
+
+function RecordCard({ record }: { record: LatestRecord }) {
+  const parts = buildSummaryParts(record);
+  const flagLabels = decodeFlags(record.flags);
+  return (
+    <div className="card mb-2 border-0 shadow-sm">
+      <div className="card-body py-2 px-3">
+        <div className="d-flex align-items-center">
+          <small className="fw-semibold text-secondary">
+            {formatTime(record.recorded_at)}
+          </small>
+          <span
+            className={`badge ms-2 ${
+              record.record_type === "event"
+                ? "bg-info"
+                : record.record_type === "status"
+                  ? "bg-secondary"
+                  : "bg-success"
+            } bg-opacity-75`}
+          >
+            {record.record_type === "event"
+              ? "イベント"
+              : record.record_type === "status"
+                ? "ステータス"
+                : "日次"}
+          </span>
+        </div>
+        {parts.length > 0 && (
+          <div className="small text-muted mt-1">{parts.join(" / ")}</div>
+        )}
+        {flagLabels.length > 0 && (
+          <div className="mt-1">
+            {flagLabels.map((f) => (
+              <span
+                key={f}
+                className="badge bg-light text-dark border me-1"
+                style={{ fontSize: "0.7rem" }}
+              >
+                {f}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface DaySummaryProps {
+  label: string;
+  records: LatestRecord[];
+  loading: boolean;
+}
+
+function DaySummary({ label, records, loading }: DaySummaryProps) {
+  const daily = records.filter((r) => r.record_type === "daily");
+
+  const avgOf = (vals: string[]): string | null => {
+    const nums = vals.map((v) => parseFloat(v)).filter((n) => !isNaN(n));
+    if (nums.length === 0) return null;
+    return (nums.reduce((a, b) => a + b, 0) / nums.length).toFixed(1);
+  };
+
+  const avgFatigue = avgOf(daily.map((r) => r.fatigue_score));
+  const avgMood = avgOf(daily.map((r) => r.mood_score));
+  const avgMotivation = avgOf(daily.map((r) => r.motivation_score));
+
+  return (
+    <div className="p-2 rounded bg-light h-100">
+      <small
+        className="fw-bold text-muted d-block mb-1"
+        style={{ fontSize: "0.7rem" }}
+      >
+        {label}
+      </small>
+      {loading ? (
+        <small className="text-muted">読込中…</small>
+      ) : records.length === 0 ? (
+        <small className="text-muted">記録なし</small>
+      ) : (
+        <>
+          <div className="small">
+            {avgFatigue !== null && (
+              <span className="me-2">
+                疲労: <b>{avgFatigue}</b>
+              </span>
+            )}
+            {avgMood !== null && (
+              <span className="me-2">
+                気分: <b>{avgMood}</b>
+              </span>
+            )}
+            {avgMotivation !== null && (
+              <span>
+                やる気: <b>{avgMotivation}</b>
+              </span>
+            )}
+          </div>
+          <small className="text-muted">{records.length} 件</small>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function HistoryBrowser() {
+  const { token } = useAuth();
+  const today = toLocalDateStr(new Date());
+
+  const [tab, setTab] = useState<"single" | "range">("single");
+
+  // Single-date state
+  const [selectedDate, setSelectedDate] = useState(today);
+  const [dayRecords, setDayRecords] = useState<LatestRecord[]>([]);
+  const [lastWeekRecords, setLastWeekRecords] = useState<LatestRecord[]>([]);
+  const [loadingDay, setLoadingDay] = useState(false);
+  const [hasFetchedDay, setHasFetchedDay] = useState(false);
+
+  // Range state
+  const [dateFrom, setDateFrom] = useState(subDays(today, 7));
+  const [dateTo, setDateTo] = useState(today);
+  const [rangeRecords, setRangeRecords] = useState<LatestRecord[]>([]);
+  const [loadingRange, setLoadingRange] = useState(false);
+  const [hasFetchedRange, setHasFetchedRange] = useState(false);
+
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDay = useCallback(
+    async (date: string) => {
+      if (!token) return;
+      setLoadingDay(true);
+      setError(null);
+      const lastWeekDate = subDays(date, 7);
+      try {
+        const [dayRes, lastWeekRes] = await Promise.all([
+          getRecords(token, { dateFrom: date, dateTo: date, limit: 100 }),
+          getRecords(token, {
+            dateFrom: lastWeekDate,
+            dateTo: lastWeekDate,
+            limit: 100,
+          }),
+        ]);
+        setDayRecords(dayRes.records);
+        setLastWeekRecords(lastWeekRes.records);
+        setHasFetchedDay(true);
+      } catch (e) {
+        setError((e as Error).message ?? "取得に失敗しました");
+      } finally {
+        setLoadingDay(false);
+      }
+    },
+    [token],
+  );
+
+  const fetchRange = useCallback(async () => {
+    if (!token) return;
+    setLoadingRange(true);
+    setError(null);
+    try {
+      const res = await getRecords(token, { dateFrom, dateTo, limit: 200 });
+      setRangeRecords(res.records);
+      setHasFetchedRange(true);
+    } catch (e) {
+      setError((e as Error).message ?? "取得に失敗しました");
+    } finally {
+      setLoadingRange(false);
+    }
+  }, [token, dateFrom, dateTo]);
+
+  return (
+    <div>
+      <div className="btn-group w-100 mb-3" role="group">
+        <button
+          className={`btn btn-sm ${tab === "single" ? "btn-success" : "btn-outline-secondary"}`}
+          onClick={() => setTab("single")}
+        >
+          日付指定
+        </button>
+        <button
+          className={`btn btn-sm ${tab === "range" ? "btn-success" : "btn-outline-secondary"}`}
+          onClick={() => setTab("range")}
+        >
+          期間指定
+        </button>
+      </div>
+
+      {error && (
+        <div className="alert alert-danger py-1 small mb-3">{error}</div>
+      )}
+
+      {tab === "single" && (
+        <div>
+          <div className="d-flex gap-2 align-items-center mb-3">
+            <input
+              type="date"
+              className="form-control form-control-sm"
+              value={selectedDate}
+              max={today}
+              onChange={(e) => setSelectedDate(e.target.value)}
+            />
+            <button
+              className="btn btn-sm btn-success"
+              style={{ whiteSpace: "nowrap" }}
+              onClick={() => fetchDay(selectedDate)}
+              disabled={loadingDay}
+            >
+              {loadingDay ? "…" : "検索"}
+            </button>
+          </div>
+
+          {hasFetchedDay && (
+            <>
+              <div className="d-flex gap-2 mb-3">
+                <div className="flex-fill">
+                  <DaySummary
+                    label={selectedDate}
+                    records={dayRecords}
+                    loading={loadingDay}
+                  />
+                </div>
+                <div className="flex-fill">
+                  <DaySummary
+                    label={`先週同曜日 (${subDays(selectedDate, 7)})`}
+                    records={lastWeekRecords}
+                    loading={loadingDay}
+                  />
+                </div>
+              </div>
+
+              {dayRecords.length > 0 ? (
+                <>
+                  <small className="text-muted d-block mb-2">
+                    {dayRecords.length} 件の記録
+                  </small>
+                  {dayRecords.map((r) => (
+                    <RecordCard key={r.id} record={r} />
+                  ))}
+                </>
+              ) : (
+                !loadingDay && (
+                  <p className="text-muted small">この日の記録はありません。</p>
+                )
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {tab === "range" && (
+        <div>
+          <div className="row g-2 mb-3">
+            <div className="col">
+              <label
+                className="form-label form-label-sm mb-1 text-muted"
+                style={{ fontSize: "0.75rem" }}
+              >
+                開始日
+              </label>
+              <input
+                type="date"
+                className="form-control form-control-sm"
+                value={dateFrom}
+                max={dateTo}
+                onChange={(e) => setDateFrom(e.target.value)}
+              />
+            </div>
+            <div className="col">
+              <label
+                className="form-label form-label-sm mb-1 text-muted"
+                style={{ fontSize: "0.75rem" }}
+              >
+                終了日
+              </label>
+              <input
+                type="date"
+                className="form-control form-control-sm"
+                value={dateTo}
+                max={today}
+                onChange={(e) => setDateTo(e.target.value)}
+              />
+            </div>
+          </div>
+          <button
+            className="btn btn-sm btn-success w-100 mb-3"
+            onClick={fetchRange}
+            disabled={loadingRange}
+          >
+            {loadingRange ? "読み込み中…" : "期間で検索"}
+          </button>
+
+          {hasFetchedRange &&
+            (rangeRecords.length > 0 ? (
+              <>
+                <small className="text-muted d-block mb-2">
+                  {rangeRecords.length} 件の記録
+                </small>
+                {rangeRecords.map((r) => (
+                  <RecordCard key={r.id} record={r} />
+                ))}
+              </>
+            ) : (
+              !loadingRange && (
+                <p className="text-muted small">この期間に記録はありません。</p>
+              )
+            ))}
+
+          {!hasFetchedRange && (
+            <p className="text-muted small">
+              期間を選択して「期間で検索」を押してください。
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 関連イシュー
Closes #149

## 変更内容
- **`api.ts`**: `getRecords()` を追加。`date_from` / `date_to` / `record_type` / `limit` パラメータでフィルタリング可能
- **`HistoryBrowser.tsx`**: 新規コンポーネント
  - **日付指定タブ**: カレンダー入力で選択した日の記録一覧 + 先週同曜日との比較表示
  - **期間指定タブ**: 開始日〜終了日の範囲で最大 200 件を検索・一覧表示
  - FLAGS ビットマスクを「睡眠不足・頭痛・腹痛・運動・飲酒・カフェイン」にデコード
- **`App.tsx`**: 履歴ページに「最近の記録」「過去ログ検索」タブを追加（既存機能はそのまま維持）

## バックエンド変更なし
Lambda `get_latest` はすでに `date_from` / `date_to` を実装済み（PR #146 で対応）。

## テスト確認
- [x] pytest lambda/ -v → 159 件全 PASSED
- [x] npx tsc --noEmit → エラーなし
- [x] npm run build → 成功

## レビュー観点
- `getRecords` の URL パラメータ組み立てが正しいか
- `decodeFlags` のビットマスク演算が FLAGS 定義と一致するか（poor_sleep=1, headache=2, stomachache=4, exercise=8, alcohol=16, caffeine=32）
- 先週同曜日の日付計算（7日減算）が正しいか