### PR TITLE
feat(terraform): Amplify develop ブランチ追加によるテスト用 URL の提供

### DIFF
--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -83,28 +83,28 @@ module "apigw" {
   cognito_issuer_url = module.cognito.issuer_url
   cognito_client_id  = module.cognito.client_id
 
-  create_record_lambda_invoke_arn       = module.lambda.create_record_invoke_arn
-  get_latest_lambda_invoke_arn          = module.lambda.get_latest_invoke_arn
-  create_record_function_name           = module.lambda.create_record_function_name
-  get_latest_function_name              = module.lambda.get_latest_function_name
-  push_subscribe_lambda_invoke_arn      = module.lambda.push_subscribe_invoke_arn
-  push_subscribe_function_name          = module.lambda.push_subscribe_function_name
-  get_item_config_lambda_invoke_arn     = module.lambda.get_item_config_invoke_arn
-  get_item_config_function_name         = module.lambda.get_item_config_function_name
-  save_item_config_lambda_invoke_arn    = module.lambda.save_item_config_invoke_arn
-  save_item_config_function_name        = module.lambda.save_item_config_function_name
-  delete_record_lambda_invoke_arn       = module.lambda.delete_record_invoke_arn
-  delete_record_function_name           = module.lambda.delete_record_function_name
-  get_env_data_latest_lambda_invoke_arn = module.lambda.get_env_data_latest_invoke_arn
-  get_env_data_latest_function_name     = module.lambda.get_env_data_latest_function_name
-  get_summary_lambda_invoke_arn         = module.lambda.get_summary_invoke_arn
-  get_summary_function_name             = module.lambda.get_summary_function_name
-  export_records_lambda_invoke_arn      = module.lambda.export_records_invoke_arn
-  export_records_function_name          = module.lambda.export_records_function_name
-  get_correlation_lambda_invoke_arn        = module.lambda.get_correlation_invoke_arn
-  get_correlation_function_name            = module.lambda.get_correlation_function_name
-  get_next_day_effects_lambda_invoke_arn   = module.lambda.get_next_day_effects_invoke_arn
-  get_next_day_effects_function_name       = module.lambda.get_next_day_effects_function_name
+  create_record_lambda_invoke_arn        = module.lambda.create_record_invoke_arn
+  get_latest_lambda_invoke_arn           = module.lambda.get_latest_invoke_arn
+  create_record_function_name            = module.lambda.create_record_function_name
+  get_latest_function_name               = module.lambda.get_latest_function_name
+  push_subscribe_lambda_invoke_arn       = module.lambda.push_subscribe_invoke_arn
+  push_subscribe_function_name           = module.lambda.push_subscribe_function_name
+  get_item_config_lambda_invoke_arn      = module.lambda.get_item_config_invoke_arn
+  get_item_config_function_name          = module.lambda.get_item_config_function_name
+  save_item_config_lambda_invoke_arn     = module.lambda.save_item_config_invoke_arn
+  save_item_config_function_name         = module.lambda.save_item_config_function_name
+  delete_record_lambda_invoke_arn        = module.lambda.delete_record_invoke_arn
+  delete_record_function_name            = module.lambda.delete_record_function_name
+  get_env_data_latest_lambda_invoke_arn  = module.lambda.get_env_data_latest_invoke_arn
+  get_env_data_latest_function_name      = module.lambda.get_env_data_latest_function_name
+  get_summary_lambda_invoke_arn          = module.lambda.get_summary_invoke_arn
+  get_summary_function_name              = module.lambda.get_summary_function_name
+  export_records_lambda_invoke_arn       = module.lambda.export_records_invoke_arn
+  export_records_function_name           = module.lambda.export_records_function_name
+  get_correlation_lambda_invoke_arn      = module.lambda.get_correlation_invoke_arn
+  get_correlation_function_name          = module.lambda.get_correlation_function_name
+  get_next_day_effects_lambda_invoke_arn = module.lambda.get_next_day_effects_invoke_arn
+  get_next_day_effects_function_name     = module.lambda.get_next_day_effects_function_name
 }
 
 # ── Amplify (React frontend hosting) ─────────────────────────────────────────

--- a/terraform/envs/prod/main.tf
+++ b/terraform/envs/prod/main.tf
@@ -101,8 +101,10 @@ module "apigw" {
   get_summary_function_name             = module.lambda.get_summary_function_name
   export_records_lambda_invoke_arn      = module.lambda.export_records_invoke_arn
   export_records_function_name          = module.lambda.export_records_function_name
-  get_correlation_lambda_invoke_arn     = module.lambda.get_correlation_invoke_arn
-  get_correlation_function_name         = module.lambda.get_correlation_function_name
+  get_correlation_lambda_invoke_arn        = module.lambda.get_correlation_invoke_arn
+  get_correlation_function_name            = module.lambda.get_correlation_function_name
+  get_next_day_effects_lambda_invoke_arn   = module.lambda.get_next_day_effects_invoke_arn
+  get_next_day_effects_function_name       = module.lambda.get_next_day_effects_function_name
 }
 
 # ── Amplify (React frontend hosting) ─────────────────────────────────────────
@@ -405,6 +407,7 @@ module "env_data_ingest" {
 # ── Outputs ────────────────────────────────────────────────────────────────────
 output "api_endpoint" { value = module.apigw.endpoint_url }
 output "amplify_app_url" { value = module.amplify.app_url }
+output "amplify_develop_url" { value = module.amplify.develop_url }
 output "cognito_user_pool_id" { value = module.cognito.user_pool_id }
 output "cognito_client_id" { value = module.cognito.client_id }
 output "github_actions_role" { value = aws_iam_role.github_actions.arn }

--- a/terraform/modules/amplify/main.tf
+++ b/terraform/modules/amplify/main.tf
@@ -81,3 +81,12 @@ resource "aws_amplify_branch" "main" {
   framework         = "React"
   stage             = "PRODUCTION"
 }
+
+resource "aws_amplify_branch" "develop" {
+  app_id      = aws_amplify_app.main.id
+  branch_name = "develop"
+
+  enable_auto_build = true
+  framework         = "React"
+  stage             = "DEVELOPMENT"
+}

--- a/terraform/modules/amplify/outputs.tf
+++ b/terraform/modules/amplify/outputs.tf
@@ -1,3 +1,4 @@
 output "app_id" { value = aws_amplify_app.main.id }
 output "default_domain" { value = aws_amplify_app.main.default_domain }
 output "app_url" { value = "https://main.${aws_amplify_app.main.default_domain}" }
+output "develop_url" { value = "https://develop.${aws_amplify_app.main.default_domain}" }

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -301,8 +301,8 @@ resource "aws_iam_role_policy" "scheduler" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Effect   = "Allow"
-      Action   = ["lambda:InvokeFunction"]
+      Effect = "Allow"
+      Action = ["lambda:InvokeFunction"]
       Resource = [
         aws_lambda_function.push_notify.arn,
         aws_lambda_function.weekly_push_notify.arn,


### PR DESCRIPTION
## Summary

- `terraform/modules/amplify/main.tf` に `aws_amplify_branch.develop` を追加
- `terraform/modules/amplify/outputs.tf` に `develop_url` 出力を追加
- `terraform/envs/prod/main.tf` に `amplify_develop_url` 出力を追加

Closes #175

## 適用手順

1. `terraform apply` → `amplify_develop_url` を確認
2. `terraform.tfvars` の `cognito_callback_urls` と `cors_allow_origins` に develop URL を追加
3. 再 `terraform apply`
4. `develop` ブランチを push → Amplify が自動ビルド

## Test plan

- [ ] `terraform plan` で `aws_amplify_branch.develop` の追加のみが表示されることを確認
- [ ] `terraform apply` 後に `amplify_develop_url` が出力されることを確認
- [ ] `develop` ブランチ push で Amplify ビルドが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)