### PR TITLE
docs: README から未設定の MIT ライセンス表記を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,3 @@ terraform init && terraform apply
 - オフライン時の POST は IndexedDB キューに保存（`useOfflineQueue` hook）
 - オンライン復帰時に自動送信
 
-## License
-
-MIT


### PR DESCRIPTION
## Summary

- 意図せず追加されていた `## License` セクション（MIT）を削除
- `LICENSE` ファイルも存在しないため、著作権は作者に帰属する状態に整理

## Test plan

- [ ] README.md に License セクションが存在しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)